### PR TITLE
Fix pylint import-error on integration tests

### DIFF
--- a/tests/integration/test_paths_edges.py
+++ b/tests/integration/test_paths_edges.py
@@ -1,6 +1,7 @@
 """Module to test the KytosGraph in graph.py."""
 from itertools import combinations
 
+# pylint: disable=import-error
 from tests.integration.edges_settings import EdgesSettings
 
 

--- a/tests/integration/test_paths_metadata.py
+++ b/tests/integration/test_paths_metadata.py
@@ -1,6 +1,6 @@
 """Module to test the KytosGraph in graph.py."""
 
-# pylint: disable=too-many-public-methods
+# pylint: disable=too-many-public-methods, import-error
 from tests.integration.metadata_settings import MetadataSettings
 
 

--- a/tests/integration/test_paths_simple.py
+++ b/tests/integration/test_paths_simple.py
@@ -2,6 +2,7 @@
 from kytos.core.link import Link
 
 # module under test
+# pylint: disable=import-error
 from tests.integration.test_paths import TestPaths
 
 


### PR DESCRIPTION
Fixes #2 

### Description of the change

This PR just disables pylint import-error checks for `tests/integration/test_paths_metadata.py` and `tests/integration/test_paths_edges.py`. A similar approach was already adopted in the helper classes (https://github.com/kytos-ng/pathfinder/blob/master/tests/integration/edges_settings.py#L6-L7 and https://github.com/kytos-ng/pathfinder/blob/master/tests/integration/metadata_settings.py#L3-L4).

### Release notes

N/A