### PR TITLE
[Fix] graph node `status` wasn't being considered when adding nodes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,14 @@ Fixed
 Security
 ========
 
+[2022.1.0] - 2022-01-25
+***********************
+
+Changed
+=======
+- Adapted ``update_nodes`` to only add if node.status is ``EntityStatus.UP``
+- Adapted ``update_links`` to only add if link.status is ``EntityStatus.UP``
+
 [2.4.0] - 2021-12-20
 ********************
 

--- a/graph.py
+++ b/graph.py
@@ -4,6 +4,7 @@
 from itertools import combinations, islice
 
 from kytos.core import log
+from kytos.core.common import EntityStatus
 from napps.kytos.pathfinder.utils import (filter_ge, filter_in, filter_le,
                                           lazy_filter, nx_edge_data_delay,
                                           nx_edge_data_priority,
@@ -50,11 +51,14 @@ class KytosGraph:
         """Update all nodes inside the graph."""
         for node in nodes.values():
             try:
+                if node.status != EntityStatus.UP:
+                    continue
                 self.graph.add_node(node.id)
 
                 for interface in node.interfaces.values():
-                    self.graph.add_node(interface.id)
-                    self.graph.add_edge(node.id, interface.id)
+                    if interface.status == EntityStatus.UP:
+                        self.graph.add_node(interface.id)
+                        self.graph.add_edge(node.id, interface.id)
 
             except AttributeError as err:
                 raise TypeError(
@@ -64,7 +68,7 @@ class KytosGraph:
     def update_links(self, links):
         """Update all links inside the graph."""
         for link in links.values():
-            if link.is_active():
+            if link.status == EntityStatus.UP:
                 self.graph.add_edge(link.endpoint_a.id, link.endpoint_b.id)
                 self.update_link_metadata(link)
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "pathfinder",
   "description": "Keeps track of topology changes, and calculates the best path between two points.",
-  "version": "2.4.0",
+  "version": "2022.1.0",
   "napp_dependencies": ["kytos/topology"],
   "license": "MIT",
   "tags": ["pathfinder", "rest", "work-in-progress"],

--- a/main.py
+++ b/main.py
@@ -195,6 +195,10 @@ class Main(KytosNApp):
         return jsonify({"paths": paths})
 
     @listen_to("kytos.topology.updated")
+    def on_topology_updated(self, event):
+        """Update the graph when the network topology is updated."""
+        self.update_topology(event)
+
     def update_topology(self, event):
         """Update the graph when the network topology is updated."""
         if "topology" not in event.content:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if 'bdist_wheel' in sys.argv:
 BASE_ENV = Path(os.environ.get('VIRTUAL_ENV', '/'))
 
 NAPP_NAME = 'pathfinder'
-NAPP_VERSION = '2.4.0'
+NAPP_VERSION = '2022.1.0'
 
 # Kytos var folder
 VAR_PATH = BASE_ENV / 'var' / 'lib' / 'kytos'

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 from kytos.core.interface import Interface
 from kytos.core.link import Link
 from kytos.core.switch import Switch
+from kytos.core.common import EntityStatus
 from kytos.lib.helpers import (get_interface_mock, get_link_mock,
                                get_switch_mock)
 
@@ -13,17 +14,26 @@ from kytos.lib.helpers import (get_interface_mock, get_link_mock,
 def get_topology_mock():
     """Create a default topology."""
     switch_a = get_switch_mock("00:00:00:00:00:00:00:01", 0x04)
+    switch_a.status = EntityStatus.UP
     switch_b = get_switch_mock("00:00:00:00:00:00:00:02", 0x04)
+    switch_b.status = EntityStatus.UP
     switch_c = get_switch_mock("00:00:00:00:00:00:00:03", 0x01)
+    switch_c.status = EntityStatus.UP
 
     interface_a1 = get_interface_mock("s1-eth1", 1, switch_a)
+    interface_a1.status = EntityStatus.UP
     interface_a2 = get_interface_mock("s1-eth2", 2, switch_a)
+    interface_a2.status = EntityStatus.UP
 
     interface_b1 = get_interface_mock("s2-eth1", 1, switch_b)
+    interface_b1.status = EntityStatus.UP
     interface_b2 = get_interface_mock("s2-eth2", 2, switch_b)
+    interface_b2.status = EntityStatus.UP
 
     interface_c1 = get_interface_mock("s3-eth1", 1, switch_c)
+    interface_c1.status = EntityStatus.UP
     interface_c2 = get_interface_mock("s3-eth2", 2, switch_c)
+    interface_c2.status = EntityStatus.UP
 
     switch_a.interfaces = {
         interface_a1.id: interface_a1,
@@ -39,8 +49,11 @@ def get_topology_mock():
     }
 
     link_1 = get_link_mock(interface_a1, interface_b1)
+    link_1.status = EntityStatus.UP
     link_2 = get_link_mock(interface_a2, interface_c1)
+    link_2.status = EntityStatus.UP
     link_3 = get_link_mock(interface_b2, interface_c2)
+    link_3.status = EntityStatus.UP
 
     topology = MagicMock()
     topology.links = {"1": link_1, "2": link_2, "3": link_3}

--- a/tests/integration/edges_settings.py
+++ b/tests/integration/edges_settings.py
@@ -271,3 +271,7 @@ class EdgesSettings(TestPaths):
         links["User1:4<->User4:3"] = Link(
             interfaces["User1:4"], interfaces["User4:3"]
         )
+
+        for link in links.values():
+            link.enable()
+            link.activate()

--- a/tests/integration/test_paths.py
+++ b/tests/integration/test_paths.py
@@ -36,7 +36,9 @@ class TestPaths(TestCase):
     @staticmethod
     def create_switch(name, switches):
         """Add a new switch to the list of switches"""
-        switches[name] = Switch(name)
+        switch = Switch(name)
+        switch.is_active = lambda: True
+        switches[name] = switch
 
     @staticmethod
     def add_interfaces(count, switch, interfaces):
@@ -44,6 +46,8 @@ class TestPaths(TestCase):
         for i in range(1, count + 1):
             str1 = f"{switch.dpid}:{i}"
             interface = Interface(str1, i, switch)
+            interface.enable()
+            interface.activate()
             interfaces[str1] = interface
             switch.update_interface(interface)
 
@@ -52,9 +56,12 @@ class TestPaths(TestCase):
         """Add a new link between two interfaces into the list of links"""
         compounded = f"{interface_a}|{interface_b}"
         final_name = compounded
-        links[final_name] = Link(
+        link = Link(
             interfaces[interface_a], interfaces[interface_b]
         )
+        link.enable()
+        link.activate()
+        links[final_name] = link
 
     @staticmethod
     def add_metadata_to_link(interface_a, interface_b, metrics, links):

--- a/tests/integration/test_paths_simple.py
+++ b/tests/integration/test_paths_simple.py
@@ -126,4 +126,8 @@ class TestPathsSimple(TestPaths):
             {"bandwidth": 49, "ownership": "blue"}
         )
 
+        for link in links.values():
+            link.enable()
+            link.activate()
+
         return switches, links


### PR DESCRIPTION
Fixes #10 

This PR depends on [`topology PR 50`](https://github.com/kytos-ng/topology/pull/50/files) 

### Description of the change

It turns out that `update_nodes` wasn't considering the status of the node, so it was adding nodes that could be down or even disabled, I've also adapted `update_links` in the same way. 

#### Changed

- Adapted ``update_nodes`` to only add if node.status is ``EntityStatus.UP``
- Adapted ``update_links`` to only add if link.status is ``EntityStatus.UP``
