### PR TITLE
[Fix] UI link description to use metadata.link_name if it's set

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,14 @@ Fixed
 Security
 ========
 
+[2022.1.1] - 2022-02-02
+***********************
+
+Changed
+=======
+- Changed UI ``k-select`` links items description to try to use ``link.metadata.link_name``
+
+
 [2022.1.0] - 2022-01-25
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "pathfinder",
   "description": "Keeps track of topology changes, and calculates the best path between two points.",
-  "version": "2022.1.0",
+  "version": "2022.1.1",
   "napp_dependencies": ["kytos/topology"],
   "license": "MIT",
   "tags": ["pathfinder", "rest", "work-in-progress"],

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if 'bdist_wheel' in sys.argv:
 BASE_ENV = Path(os.environ.get('VIRTUAL_ENV', '/'))
 
 NAPP_NAME = 'pathfinder'
-NAPP_VERSION = '2022.1.0'
+NAPP_VERSION = '2022.1.1'
 
 # Kytos var folder
 VAR_PATH = BASE_ENV / 'var' / 'lib' / 'kytos'

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -251,8 +251,8 @@ module.exports = {
     get_links(){
       var links = []
       $.each(this.links, function(key, value){
-        if (value.metadata.aliases != undefined && value.metadata.aliases.length != 0){
-          links.push({value:value.id, description:value.metadata.aliases[0]})
+        if (value.metadata.link_name !== undefined && value.metadata.link_name.length !== 0){
+          links.push({value:value.id, description:value.metadata.link_name})
         } else {
           links.push({value:value.id, description:value.id});
         }


### PR DESCRIPTION
Fixes #12 

### Release notes

#### Changed
- Changed UI ``k-select`` links items description to try to use ``link.metadata.link_name``


**Heads up**: We'll probably need to do the same for the interfaces list, I'll map this one as soon as it's confirmed

#### Testing locally

- If `link_name` isn't set it'll still fallback to use `id`, as you can see below we have two links and only one has `link_name` set:

![2022-02-02-115459_1057x591_scrot](https://user-images.githubusercontent.com/1010796/152182680-cfbd5bf9-5300-4e57-a18d-e31c240679dd.png)

