### PR TITLE
[Fix] undesired_links (logical OR) and desired_links (logical AND) filters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,7 +20,7 @@ Removed
 
 Fixed
 =====
-- Fixed ``undesired_links`` and ``desired_links`` filters
+- Fixed ``undesired_links`` (logical OR) and ``desired_links`` (logical AND) filters.
 
 Security
 ========

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ All notable changes to the pathfinder NApp will be documented in this file.
 ********************************
 Added
 =====
+- Subscribed to ``kytos/topology.topology_loaded`` to be more promptly responsive
 
 Changed
 =======
@@ -19,6 +20,7 @@ Removed
 
 Fixed
 =====
+- Fixed ``undesired_links`` and ``desired_links`` filters
 
 Security
 ========

--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,7 @@ Events
 Subscribed
 ----------
 
+- ``kytos/topology.topology_loaded``
 - ``kytos/topology.updated``
 - ``kytos/topology.links.metadata.(added|removed)``
 

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 """Main module of kytos/pathfinder Kytos Network Application."""
 
+from typing import Generator
 from threading import Lock
 
 from flask import jsonify, request
@@ -50,19 +51,17 @@ class Main(KytosNApp):
 
     def _find_any_link_ids(
         self, paths: list[dict], link_ids: list[str]
-    ) -> set[int]:
+    ) -> Generator[int, None, None]:
         """Find indexes of the paths that contain any of the link ids."""
         endpoints_links = self._map_endpoints_from_link_ids(link_ids)
-        indexes: set[int] = set()
         for idx, path in enumerate(paths):
-            head, tail = path["hops"][:-1], path["hops"][1:]
-            if idx in indexes:
-                continue
+            head, tail, found = path["hops"][:-1], path["hops"][1:], False
             for endpoints in zip(head, tail):
                 if endpoints in endpoints_links:
-                    indexes.add(idx)
+                    found = True
                     break
-        return indexes
+            if found:
+                yield idx
 
     def _filter_paths_undesired_links(
         self, paths: list[dict], undesired: list[str]

--- a/main.py
+++ b/main.py
@@ -106,7 +106,6 @@ class Main(KytosNApp):
         if not desired:
             return paths
         included_indexes = set(self._find_all_link_ids(paths, desired))
-        print(included_indexes, desired)
         return [path for idx, path in enumerate(paths) if idx in included_indexes]
 
     def _validate_payload(self, data):

--- a/main.py
+++ b/main.py
@@ -1,13 +1,12 @@
 """Main module of kytos/pathfinder Kytos Network Application."""
 
-from typing import Generator
 from threading import Lock
+from typing import Generator
 
 from flask import jsonify, request
 from kytos.core import KytosNApp, log, rest
 from kytos.core.helpers import listen_to
 from napps.kytos.pathfinder.graph import KytosGraph
-
 # pylint: disable=import-error
 from werkzeug.exceptions import BadRequest
 

--- a/main.py
+++ b/main.py
@@ -29,57 +29,58 @@ class Main(KytosNApp):
     def shutdown(self):
         """Shutdown the napp."""
 
-    def _filter_paths(self, paths, desired, undesired):
-        """
-        Apply filters to the paths list.
-
-        Make sure that each path in the list has all the desired links and none
-        of the undesired ones.
-        """
-        filtered_paths = []
-
-        if desired:
-            for link_id in desired:
-                try:
-                    endpoint_a = self._topology.links[link_id].endpoint_a.id
-                    endpoint_b = self._topology.links[link_id].endpoint_b.id
-                except KeyError:
-                    return []
-
-                for path in paths:
-                    head = path["hops"][:-1]
-                    tail = path["hops"][1:]
-                    if ((endpoint_a, endpoint_b) in zip(head, tail)) or (
-                        (endpoint_b, endpoint_a) in zip(head, tail)
-                    ):
-                        filtered_paths.append(path)
-        else:
-            filtered_paths = paths
-
-        if undesired:
-            for link_id in undesired:
-                try:
-                    endpoint_a = self._topology.links[link_id].endpoint_a.id
-                    endpoint_b = self._topology.links[link_id].endpoint_b.id
-                except KeyError:
-                    continue
-
-                for path in paths:
-                    head = path["hops"][:-1]
-                    tail = path["hops"][1:]
-                    if ((endpoint_a, endpoint_b) in zip(head, tail)) or (
-                        (endpoint_b, endpoint_a) in zip(head, tail)
-                    ):
-
-                        filtered_paths.remove(path)
-
-        return filtered_paths
-
     def _filter_paths_le_cost(self, paths, max_cost):
         """Filter by paths where the cost is le <= max_cost."""
         if not max_cost:
             return paths
         return [path for path in paths if path["cost"] <= max_cost]
+
+    def _map_endpoints_from_link_ids(self, link_ids: list[str]) -> dict:
+        """Map endpoints from link ids."""
+        endpoints = {}
+        for link_id in link_ids:
+            try:
+                link = self._topology.links[link_id]
+                endpoint_a, endpoint_b = link.endpoint_a, link.endpoint_b
+                endpoints[(endpoint_a.id, endpoint_b.id)] = link
+                endpoints[(endpoint_b.id, endpoint_a.id)] = link
+            except KeyError:
+                pass
+        return endpoints
+
+    def _find_any_link_ids(
+        self, paths: list[dict], link_ids: list[str]
+    ) -> set[int]:
+        """Find indexes of the paths that contain any of the link ids."""
+        endpoints_links = self._map_endpoints_from_link_ids(link_ids)
+        indexes: set[int] = set()
+        for idx, path in enumerate(paths):
+            head, tail = path["hops"][:-1], path["hops"][1:]
+            if idx in indexes:
+                continue
+            for endpoints in zip(head, tail):
+                if endpoints in endpoints_links:
+                    indexes.add(idx)
+                    break
+        return indexes
+
+    def _filter_paths_undesired_links(
+        self, paths: list[dict], undesired: list[str]
+    ) -> list[dict]:
+        """Filter by undesired_links, it performs a logical OR."""
+        if not undesired:
+            return paths
+        excluded_indexes = self._find_any_link_ids(paths, undesired)
+        return [path for idx, path in enumerate(paths) if idx not in excluded_indexes]
+
+    def _filter_paths_desired_links(
+        self, paths: list[dict], desired: list[str]
+    ) -> list[dict]:
+        """Filter by desired_links, it performs a logical OR."""
+        if not desired:
+            return paths
+        included_indexes = self._find_any_link_ids(paths, desired)
+        return [path for idx, path in enumerate(paths) if idx in included_indexes]
 
     def _validate_payload(self, data):
         """Validate shortest_path v2/ POST endpoint."""
@@ -189,12 +190,13 @@ class Main(KytosNApp):
         except TypeError as err:
             raise BadRequest(str(err))
 
-        paths = self._filter_paths(paths, desired, undesired)
         paths = self._filter_paths_le_cost(paths, max_cost=spf_max_path_cost)
+        paths = self._filter_paths_undesired_links(paths, undesired)
+        paths = self._filter_paths_desired_links(paths, desired)
         log.debug(f"Filtered paths: {paths}")
         return jsonify({"paths": paths})
 
-    @listen_to("kytos.topology.updated")
+    @listen_to("kytos.topology.updated", "kytos/topology.topology_loaded")
     def on_topology_updated(self, event):
         """Update the graph when the network topology is updated."""
         self.update_topology(event)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -164,7 +164,7 @@ class TestMain(TestCase):
                     "00:00:00:00:00:00:00:01:1",
                     "00:00:00:00:00:00:00:02:1",
                     "00:00:00:00:00:00:00:02:2",
-                    "00:00:00:00:00:00:00:03:1",
+                    "00:00:00:00:00:00:00:03:3",
                 ]
             },
             {
@@ -177,10 +177,10 @@ class TestMain(TestCase):
                 "cost": 3,
             },
         ]
-        link_id = "1"
-        desired = [link_id]
+        desired = ["1", "3"]
 
-        assert self.napp._topology.links[link_id]
+        for link in desired:
+            assert self.napp._topology.links[link]
         filtered_paths = self.napp._filter_paths_desired_links(paths, desired)
         assert filtered_paths == [paths[0]]
 
@@ -226,13 +226,21 @@ class TestMain(TestCase):
                     "00:00:00:00:00:00:00:01:1",
                     "00:00:00:00:00:00:00:02:1",
                     "00:00:00:00:00:00:00:02:2",
-                    "00:00:00:00:00:00:00:03:1",
+                    "00:00:00:00:00:00:00:03:2",
                 ]
             }
         ]
 
-        undesired = ["2"]
-        filtered_paths = self.napp._filter_paths_desired_links(paths, undesired)
+        undesired = ["1"]
+        filtered_paths = self.napp._filter_paths_undesired_links(paths, undesired)
+        assert not filtered_paths
+
+        undesired = ["3"]
+        filtered_paths = self.napp._filter_paths_undesired_links(paths, undesired)
+        assert not filtered_paths
+
+        undesired = ["1", "3"]
+        filtered_paths = self.napp._filter_paths_undesired_links(paths, undesired)
         assert not filtered_paths
 
         filtered_paths = self.napp._filter_paths_undesired_links(paths, ["none"])

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -164,7 +164,7 @@ class TestMain(TestCase):
                     "00:00:00:00:00:00:00:01:1",
                     "00:00:00:00:00:00:00:02:1",
                     "00:00:00:00:00:00:00:02:2",
-                    "00:00:00:00:00:00:00:03:3",
+                    "00:00:00:00:00:00:00:03:2",
                 ]
             },
             {
@@ -183,6 +183,9 @@ class TestMain(TestCase):
             assert self.napp._topology.links[link]
         filtered_paths = self.napp._filter_paths_desired_links(paths, desired)
         assert filtered_paths == [paths[0]]
+
+        filtered_paths = self.napp._filter_paths_desired_links(paths, ["1", "2"])
+        assert not filtered_paths
 
         filtered_paths = self.napp._filter_paths_desired_links(paths, ["inexistent_id"])
         assert not filtered_paths

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -163,13 +163,29 @@ class TestMain(TestCase):
                 "hops": [
                     "00:00:00:00:00:00:00:01:1",
                     "00:00:00:00:00:00:00:02:1",
+                    "00:00:00:00:00:00:00:02:2",
+                    "00:00:00:00:00:00:00:03:1",
                 ]
-            }
+            },
+            {
+                "hops": [
+                    "00:00:00:00:00:00:00:01:1",
+                    "00:00:00:00:00:00:00:01",
+                    "00:00:00:00:00:00:00:04",
+                    "00:00:00:00:00:00:00:04:1",
+                ],
+                "cost": 3,
+            },
         ]
-        desired, undesired = ["1"], None
+        link_id = "1"
+        desired = [link_id]
 
-        filtered_paths = self.napp._filter_paths(paths, desired, undesired)
-        self.assertEqual(filtered_paths, paths)
+        assert self.napp._topology.links[link_id]
+        filtered_paths = self.napp._filter_paths_desired_links(paths, desired)
+        assert filtered_paths == [paths[0]]
+
+        filtered_paths = self.napp._filter_paths_desired_links(paths, ["inexistent_id"])
+        assert not filtered_paths
 
     def test_filter_paths_le_cost_response(self):
         """Test filter paths."""
@@ -207,14 +223,20 @@ class TestMain(TestCase):
         paths = [
             {
                 "hops": [
-                    "00:00:00:00:00:00:00:01:2",
+                    "00:00:00:00:00:00:00:01:1",
+                    "00:00:00:00:00:00:00:02:1",
+                    "00:00:00:00:00:00:00:02:2",
                     "00:00:00:00:00:00:00:03:1",
                 ]
             }
         ]
-        desired, undesired = None, ["2"]
-        filtered_paths = self.napp._filter_paths(paths, desired, undesired)
-        self.assertEqual(filtered_paths, [])
+
+        undesired = ["2"]
+        filtered_paths = self.napp._filter_paths_desired_links(paths, undesired)
+        assert not filtered_paths
+
+        filtered_paths = self.napp._filter_paths_undesired_links(paths, ["none"])
+        assert filtered_paths == paths
 
     def setting_path(self):
         """Set the primary elements needed to test the topology


### PR DESCRIPTION
This PR supersedes PR #28 (it also fixes issue 29)

Fixes #20 #27 #29

- Fixed ``undesired_links`` (logical OR) and ``desired_links`` filters (logical AND) 
- Subscribed to ``kytos/topology.topology_loaded`` as well to be more promptly responsive 


I've explored it locally with the same topology that Italo has initially reported the issue and same request, here's a diff of the response:

```
❯ diff /tmp/resp_master.json /tmp/resp_fix.json
11,30d10
<         "00:00:00:00:00:00:00:02:3",
<         "00:00:00:00:00:00:00:03:2",
<         "00:00:00:00:00:00:00:03",
<         "00:00:00:00:00:00:00:03:4",
<         "00:00:00:00:00:00:00:06:5",
<         "00:00:00:00:00:00:00:06",
<         "00:00:00:00:00:00:00:06:2",
<         "00:00:00:00:00:00:00:05:3",
<         "00:00:00:00:00:00:00:05",
<         "00:00:00:00:00:00:00:05:1"
<       ]
<     },
<     {
<       "cost": 14,
<       "hops": [
<         "00:00:00:00:00:00:00:01:1",
<         "00:00:00:00:00:00:00:01",
<         "00:00:00:00:00:00:00:01:2",
<         "00:00:00:00:00:00:00:02:2",
<         "00:00:00:00:00:00:00:02",

```

- If you grep for the endpoints on `master` branch you'd find the `undesired_links` included:

```
❯ rg "00:00:00:00:00:00:00:01:3|00:00:00:00:00:00:00:06:3|00:00:00:00:00:00:00:05:3|00:00:00:00:00:00:00:06:2" /tmp/resp_master.json
17:        "00:00:00:00:00:00:00:06:2",
18:        "00:00:00:00:00:00:00:05:3",
```

- If you grep for the expected excluded links/endpoints with this branch they got excluded:

```
❯ rg "00:00:00:00:00:00:00:01:3|00:00:00:00:00:00:00:06:3|00:00:00:00:00:00:00:05:3|00:00:00:00:00:00:00:06:2" /tmp/resp_fix.json
```

I've also re-run the same example of issue #27, no longer duplicated paths are being seeing in the response, and `desired_links` now can be used to narrow down a set of links in the path.  In the future, we might also have the logical expression being parametrized.