### PR TITLE
[Fix] Subscribed to kytos/topology.current to try to reconciliate the topology

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ All notable changes to the pathfinder NApp will be documented in this file.
 Added
 =====
 - Subscribed to ``kytos/topology.topology_loaded`` to be more promptly responsive
+- Subscribed to ``kytos/topology.current``
+- Updated ``on_links_metadata_changed`` to also try to reconciliate the topology
 
 Changed
 =======

--- a/main.py
+++ b/main.py
@@ -7,7 +7,6 @@ from flask import jsonify, request
 from kytos.core import KytosEvent, KytosNApp, log, rest
 from kytos.core.helpers import listen_to
 from napps.kytos.pathfinder.graph import KytosGraph
-
 # pylint: disable=import-error
 from werkzeug.exceptions import BadRequest
 

--- a/main.py
+++ b/main.py
@@ -4,9 +4,10 @@ from threading import Lock
 from typing import Generator
 
 from flask import jsonify, request
-from kytos.core import KytosNApp, log, rest
+from kytos.core import KytosEvent, KytosNApp, log, rest
 from kytos.core.helpers import listen_to
 from napps.kytos.pathfinder.graph import KytosGraph
+
 # pylint: disable=import-error
 from werkzeug.exceptions import BadRequest
 
@@ -221,7 +222,11 @@ class Main(KytosNApp):
         log.debug(f"Filtered paths: {paths}")
         return jsonify({"paths": paths})
 
-    @listen_to("kytos.topology.updated", "kytos/topology.topology_loaded")
+    @listen_to(
+        "kytos.topology.updated",
+        "kytos/topology.current",
+        "kytos/topology.topology_loaded",
+    )
     def on_topology_updated(self, event):
         """Update the graph when the network topology is updated."""
         self.update_topology(event)
@@ -234,13 +239,26 @@ class Main(KytosNApp):
         with self._lock:
             self._topology = topology
             self.graph.update_topology(topology)
-        log.debug("Topology graph updated.")
+        switches = list(topology.switches.keys())
+        links = list(topology.links.keys())
+        log.debug(f"Topology graph updated with switches: {switches}, links: {links}.")
+
+    def update_links_metadata_changed(self, event) -> None:
+        """Update the graph when links' metadata are added or removed."""
+        link = event.content["link"]
+        try:
+            with self._lock:
+                self.graph.update_link_metadata(link)
+            metadata = event.content["metadata"]
+            log.debug(f"Topology graph updated link id: {link.id} metadata: {metadata}")
+        except KeyError as exc:
+            log.warning(
+                f"Unexpected KeyError {str(exc)} on event {event}."
+                " pathfinder will reconciliate the topology"
+            )
+            self.controller.buffers.app.put(KytosEvent(name="kytos/topology.get"))
 
     @listen_to("kytos/topology.links.metadata.(added|removed)")
     def on_links_metadata_changed(self, event):
         """Update the graph when links' metadata are added or removed."""
-        link = event.content["link"]
-        with self._lock:
-            self.graph.update_link_metadata(link)
-        metadata = event.content["metadata"]
-        log.debug(f"Topology graph updated link id: {link.id} metadata: {metadata}")
+        self.update_links_metadata_changed(event)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,7 +1,7 @@
 """Test Main methods."""
 
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from kytos.core.events import KytosEvent
 from kytos.lib.helpers import get_controller_mock, get_test_client
@@ -257,6 +257,30 @@ class TestMain(TestCase):
             name="kytos.topology.updated", content={"topology": topology}
         )
         self.napp.update_topology(event)
+
+    def test_update_links_changed(self):
+        """Test update_links_metadata_changed."""
+        self.napp.graph.update_link_metadata = MagicMock()
+        self.napp.controller.buffers.app.put = MagicMock()
+        event = KytosEvent(
+            name="kytos.topology.links.metadata.added",
+            content={"link": MagicMock(), "metadata": {}}
+        )
+        self.napp.update_links_metadata_changed(event)
+        assert self.napp.graph.update_link_metadata.call_count == 1
+        assert self.napp.controller.buffers.app.put.call_count == 0
+
+    def test_update_links_changed_key_error(self):
+        """Test update_links_metadata_changed key_error."""
+        self.napp.graph.update_link_metadata = MagicMock()
+        self.napp.controller.buffers.app.put = MagicMock()
+        event = KytosEvent(
+            name="kytos.topology.links.metadata.added",
+            content={"link": MagicMock()}
+        )
+        self.napp.update_links_metadata_changed(event)
+        assert self.napp.graph.update_link_metadata.call_count == 1
+        assert self.napp.controller.buffers.app.put.call_count == 1
 
     def test_shortest_path(self):
         """Test shortest path."""


### PR DESCRIPTION
Fixes #33 

This is for helping out to fix this current issue that was caught on e2e tests, it'll provide a way to try to reconciliate the topology when updating a link metadata, although this doesn't fix the root cause it'll provide a recovery reconciliation mechanism:

https://github.com/amlight/kytos-end-to-end-tests/issues/179
https://github.com/kytos-ng/topology/pull/112 (it also depends on this `topology` PR)

### Changelog

- Subscribed to ``kytos/topology.current``
- Updated ``on_links_metadata_changed`` to also try to reconciliate the topology

### Local tests

I've simulated a `KeyError` analogous to the one that happened on the e2e tests, when it happens it reconciliated the topology in a few milliseconds assuming not much messaging overload going on:

```
2022-11-02 18:15:08,708 - INFO [werkzeug] [_internal.py:225:_log] (Thread-109) 127.0.0.1 - - [02/Nov/2022 18:15:08] "POST /api/kytos/topology/v3/links/4d42dc0852278accac7d9df15418f6d921
db160b13d674029a87cef1b5f67f30/metadata HTTP/1.1" 201 -
2022-11-02 18:15:08,709 - WARNING [kytos.napps.kytos/pathfinder] [main.py:255:update_links_metadata_changed] (thread_pool_app_6) Unexpected KeyError 'what' on event kytos/topology.links
.metadata.added. pathfinder will reconciliate the topology
2022-11-02 18:15:08,713 - INFO [kytos.napps.kytos/pathfinder] [main.py:243:update_topology] (thread_pool_app_2) Topology graph updated with switches: ['00:00:00:00:00:00:00:01', '00:00:
00:00:00:00:00:02', '00:00:00:00:00:00:00:03'], links: ['4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30', '78282c4d5b579265f04ebadc4405ca1b49628eb1d684bb45e5d0607fa8b7
13d0', 'c8b55359990f89a5849813dc348d30e9e1f991bad1dcb7f82112bd35429d9b07'].

```

I'll keep also running e2e more executions of this test case `test_001_create_delete_create_with_constraints`, let's see if would pass 200+ iterations, if it does then it would be beneficial to ship this. 
