### PR TITLE
[release] Bumped 2022.3.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,28 +5,20 @@ All notable changes to the pathfinder NApp will be documented in this file.
 
 [UNRELEASED] - Under development
 ********************************
+
+[2022.3.0] - 2022-12-15
+***********************
+
 Added
 =====
 - Subscribed to ``kytos/topology.topology_loaded`` to be more promptly responsive
 - Subscribed to ``kytos/topology.current``
 - Updated ``on_links_metadata_changed`` to also try to reconciliate the topology
 
-Changed
-=======
-
-Deprecated
-==========
-
-Removed
-=======
-
 Fixed
 =====
 - Fixed ``undesired_links`` (logical OR) and ``desired_links`` (logical AND) filters.
 - Safe guards to discard graph topology older (out of order) events
-
-Security
-========
 
 [2022.1.1] - 2022-02-02
 ***********************

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "pathfinder",
   "description": "Keeps track of topology changes, and calculates the best path between two points.",
-  "version": "2022.1.1",
+  "version": "2022.3.0",
   "napp_dependencies": ["kytos/topology"],
   "license": "MIT",
   "tags": ["pathfinder", "rest", "work-in-progress"],


### PR DESCRIPTION
Closes N/A

### Summary

- Bumped 2022.3.0

I'm bumping the version of NApps that can already be bumped, when the time comes, it's just a matter of merging and creating the GitHub release with its `git` tag. 