### PR TITLE
fix: removed support for `desired_links` and fixed `undesired_links` to filter upfront as a subgraph

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,21 @@ All notable changes to the pathfinder NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+Added
+=====
+- ``POST /v3/`` has replaced ``POST /v2/``
+- ``POST /v3/`` now validates its OpenAPI spec
+
+Fixed
+=====
+
+- ``undesired_links`` links now filter upfront as a subgraph to still efficiently allow a lazy computation of k shortest (constrained) paths.
+
+Removed
+=======
+- ``desired_links`` is no longer supported. If used to use ``desired_links`` you can try to parametrize it with a different constraint for instance ``undesired_links`` or with ``mandatory_metrics``.
+- ``POST /v2/`` has been removed
+
 [2022.3.0] - 2022-12-15
 ***********************
 

--- a/graph.py
+++ b/graph.py
@@ -163,15 +163,17 @@ class KytosGraph:
         destination,
         weight=None,
         k=1,
+        graph=None,
         minimum_hits=None,
         **metrics,
     ):
         """Calculate the constrained shortest paths with flexibility."""
+        graph = graph or self.graph
         mandatory_metrics = metrics.get("mandatory_metrics", {})
         flexible_metrics = metrics.get("flexible_metrics", {})
         first_pass_links = list(
             self._filter_links(
-                self.graph.edges(data=True), **mandatory_metrics
+                graph.edges(data=True), **mandatory_metrics
             )
         )
         length = len(flexible_metrics)
@@ -192,7 +194,7 @@ class KytosGraph:
                     destination,
                     weight=weight,
                     k=k,
-                    graph=self.graph.edge_subgraph(filtered_links),
+                    graph=graph.edge_subgraph(filtered_links),
                 ):
                     paths.append(
                         {

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: kytos/pathfinder
-  version: v2
+  version: v3
   description: "**Warning**: *This documentation is experimental and will
   change soon.*\n
   ## Introduction\n
@@ -18,7 +18,7 @@ tags:
     - name: Paths
 
 paths:
-  /api/kytos/pathfinder/v2/:
+  /api/kytos/pathfinder/v3/:
     post:
       summary: Returns best paths between the source and destination.
       description: "Returns a list of k best paths between source and destination, in order.\n
@@ -56,15 +56,6 @@ paths:
                   type: string
                   description: The destination identifier. It may be a datapath or an interface.
                   example: '00:00:00:00:00:00:00:02:2'
-                desired_links:
-                  type: array
-                  description: Constraint in the form of a list of desired links inside all paths found. All paths will have the desired links.
-                  items:
-                    $ref: "#/components/schemas/Link"
-                  example:
-                    - '2bd01b0d-c875-4263-ad38-fec0b2999582'
-                    - 'c41f6249-3ea6-4aba-a083-08049face1e2'
-                    - '7e8b6bd2-701e-4465-894a-40623e727047'
                 undesired_links:
                   type: array
                   description: Constraint in the form of a list of undesired links in all paths found. When an undesired link is found the endpoint will ignore remove that.
@@ -217,6 +208,4 @@ components:
           code:
               type: integer
           description:
-              type: string
-          name:
               type: string

--- a/openapi.yml
+++ b/openapi.yml
@@ -78,7 +78,7 @@ paths:
                   description: Maximum number of 'k' best paths that should be computed by SPF. The lower the value the faster it is going to compute. If you only need a single best path, you should set this value as 1.
                   default: 2
                   minimum: 1
-                  maximum: 8
+                  maximum: 10
                 spf_max_path_cost:
                   type: number
                   description: Maximum accumulated path cost to be consireded a best path. You should only set this value if you want to set an upper bound accumulated cost.

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -124,31 +124,59 @@ module.exports = {
         }
       }
 
-      $.ajax({
+      var payload = {
+        spf_attribute: self.spf_attribute,
+        mandatory_metrics: self.mandatory_metrics,
+        flexible_metrics: self.flexible_metrics
+      }
+      if (self.source) {
+        payload["source"] = self.source
+      }
+      if (self.destination) {
+        payload["destination"] = self.destination
+      }
+      if (self.undesired_links.length) {
+        payload["undesired_links"] = self.undesired_links
+      }
+      if (Object.keys(mandatory_metrics).length) {
+        payload["mandatory_metrics"] = mandatory_metrics
+      }
+      if (Object.keys(flexible_metrics).length) {
+        payload["flexible_metrics"] = flexible_metrics
+      }
+      if (self.spf_max_paths) {
+        payload["spf_max_paths"] = self.spf_max_paths
+      }
+      if (self.spf_max_path_cost) {
+        payload["spf_max_path_cost"] = self.spf_max_path_cost
+      }
+      if (self.minimum_flexible_hits) {
+        payload["minimum_flexible_hits"] = self.minimum_flexible_hits
+      }
+
+      let request = $.ajax({
         async: true,
         dataType: "json",
         type: "POST",
         contentType: "application/json",
-        data: JSON.stringify({"source": self.source,
-               "destination": self.destination,
-               "undesired_links": self.undesired_links,
-               "mandatory_metrics": mandatory_metrics,
-               "flexible_metrics": flexible_metrics,
-               "spf_attribute": self.spf_attribute,
-               "spf_max_paths": self.spf_max_paths,
-               "spf_max_path_cost": self.spf_max_path_cost,
-               "minimum_flexible_hits": self.minimum_flexible_hits,
-               }),
-
+        data: JSON.stringify(payload),
         url: this.$kytos_server_api + "kytos/pathfinder/v3/",
-        success: function(data) {
-            if (data['paths'][0] !== undefined){
-                self.paths = data['paths'];
-            } else {
-                self.paths = []
-            }
-          self.show();
-        }
+      });
+      request.done(function(data) {
+          if (data['paths'][0] !== undefined){
+              self.paths = data['paths'];
+          } else {
+              self.paths = []
+          }
+        self.show();
+      });
+      request.fail(function(data) {
+        let notification = {
+          icon: 'gear',
+          title: 'Bad request',
+          description: data.status + ': ' + data.responseJSON.description
+        };
+        self.$kytos.$emit("setNotification", notification);
       });
     },
     get_topology(){

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -7,8 +7,6 @@
           :value.sync="source"></k-dropdown>
          <k-dropdown icon="circle-o" title="Destination:" :options="get_interfaces"
           :value.sync ="destination"></k-dropdown>
-         <k-select icon="link" title="Desired links:" :options="get_links"
-          :value.sync ="desired_links"></k-select>
          <k-select icon="link" title="Undesired links:" :options="get_links"
           :value.sync ="undesired_links"></k-select>
           <div class="metric">
@@ -133,7 +131,6 @@ module.exports = {
         contentType: "application/json",
         data: JSON.stringify({"source": self.source,
                "destination": self.destination,
-               "desired_links": self.desired_links,
                "undesired_links": self.undesired_links,
                "mandatory_metrics": mandatory_metrics,
                "flexible_metrics": flexible_metrics,
@@ -143,7 +140,7 @@ module.exports = {
                "minimum_flexible_hits": self.minimum_flexible_hits,
                }),
 
-        url: this.$kytos_server_api + "kytos/pathfinder/v2",
+        url: this.$kytos_server_api + "kytos/pathfinder/v3/",
         success: function(data) {
             if (data['paths'][0] !== undefined){
                 self.paths = data['paths'];
@@ -280,7 +277,6 @@ module.exports = {
       links: [],
       source: "",
       destination: "",
-      desired_links: [],
       undesired_links: [],
       checked_list: [],
       metrics:{


### PR DESCRIPTION
Closes #37 
Closes #46 

(before this get merged, `mef_eline` also needs to update the endpoint to /v3 and [fix this issue](https://github.com/kytos-ng/mef_eline/issues/296))

### Summary

See updated changelog file.

### Local Tests

- Request and response using a ring topology:

```
{
    "source": "00:00:00:00:00:00:00:01:1",
    "destination": "00:00:00:00:00:00:00:03:1"
}

{
    "paths": [
        {
            "hops": [
                "00:00:00:00:00:00:00:01:1",
                "00:00:00:00:00:00:00:01",
                "00:00:00:00:00:00:00:01:4",
                "00:00:00:00:00:00:00:03:3",
                "00:00:00:00:00:00:00:03",
                "00:00:00:00:00:00:00:03:1"
            ],
            "cost": 5
        },
        {
            "hops": [
                "00:00:00:00:00:00:00:01:1",
                "00:00:00:00:00:00:00:01",
                "00:00:00:00:00:00:00:01:3",
                "00:00:00:00:00:00:00:02:2",
                "00:00:00:00:00:00:00:02",
                "00:00:00:00:00:00:00:02:3",
                "00:00:00:00:00:00:00:03:2",
                "00:00:00:00:00:00:00:03",
                "00:00:00:00:00:00:00:03:1"
            ],
            "cost": 8
        }
    ]
}
```

- Request and response using a ring topology with `"undesired_links"`:

```
{
    "source": "00:00:00:00:00:00:00:01:1",
    "destination": "00:00:00:00:00:00:00:03:1",
    "undesired_links": ["{{linkid}}"]
}
{
    "paths": [
        {
            "hops": [
                "00:00:00:00:00:00:00:01:1",
                "00:00:00:00:00:00:00:01",
                "00:00:00:00:00:00:00:01:3",
                "00:00:00:00:00:00:00:02:2",
                "00:00:00:00:00:00:00:02",
                "00:00:00:00:00:00:00:02:3",
                "00:00:00:00:00:00:00:03:2",
                "00:00:00:00:00:00:00:03",
                "00:00:00:00:00:00:00:03:1"
            ],
            "cost": 8
        }
    ]
}
```

- UI tests

![20230509_183019](https://github.com/kytos-ng/pathfinder/assets/1010796/5ecfd75b-1786-4b6b-a9c2-4537ede280ad)

![20230509_183723](https://github.com/kytos-ng/pathfinder/assets/1010796/99d513f9-f2e0-49c8-a6e7-c960499a8d5b)

- I've also ran a similar test to the original case with `amlight` topo, except not using `desired_links` anymore:

```
❯ curl -s -X POST -H 'Content-type: application/json' http://127.0.0.1:8181/api/kytos/pathfinder/v3/ -d '{"source": "00:00:00:00:00:00:00:21:60", "destination":  "00:00:00:00:00:00:00:15:54", "spf_max_paths": 2, "undesired_links": ["3956ad11df6336618b11ba3da67c855f895310509d61d9f520b712e4b140320a"]}' | jq -r
{
  "paths": [
    {
      "hops": [
        "00:00:00:00:00:00:00:21:60",
        "00:00:00:00:00:00:00:21",
        "00:00:00:00:00:00:00:21:15",
        "00:00:00:00:00:00:00:19:15",
        "00:00:00:00:00:00:00:19",
        "00:00:00:00:00:00:00:19:12",
        "00:00:00:00:00:00:00:12:12",
        "00:00:00:00:00:00:00:12",
        "00:00:00:00:00:00:00:12:4",
        "00:00:00:00:00:00:00:15:4",
        "00:00:00:00:00:00:00:15",
        "00:00:00:00:00:00:00:15:54"
      ],
      "cost": 11
    },
    {
      "hops": [
        "00:00:00:00:00:00:00:21:60",
        "00:00:00:00:00:00:00:21",
        "00:00:00:00:00:00:00:21:14",
        "00:00:00:00:00:00:00:18:14",
        "00:00:00:00:00:00:00:18",
        "00:00:00:00:00:00:00:18:11",
        "00:00:00:00:00:00:00:11:11",
        "00:00:00:00:00:00:00:11",
        "00:00:00:00:00:00:00:11:1",
        "00:00:00:00:00:00:00:12:1",
        "00:00:00:00:00:00:00:12",
        "00:00:00:00:00:00:00:12:4",
        "00:00:00:00:00:00:00:15:4",
        "00:00:00:00:00:00:00:15",
        "00:00:00:00:00:00:00:15:54"
      ],
      "cost": 14
    }
  ]
}


- Excluding link b4bb0efae4ff2952171836a4c56dff63bae46a9a03ab3c3fdeec8bd66f23dad2 that belongs to 00:00:00:00:00:00:00:21:15 and 00:00:00:00:00:00:00:19:15

❯ curl -s -X POST -H 'Content-type: application/json' http://127.0.0.1:8181/api/kytos/pathfinder/v3/ -d '{"source": "00:00:00:00:00:00:00:21:60", "destination":  "00:00:00:00:00:00:00:15:54", "spf_max_paths": 2, "undesired_links": ["b4bb0efae4ff2952171836a4c56dff63bae46a9a03ab3c3fdeec8bd66f23dad2"]}' | jq -r
{
  "paths": [
    {
      "hops": [
        "00:00:00:00:00:00:00:21:60",
        "00:00:00:00:00:00:00:21",
        "00:00:00:00:00:00:00:21:14",
        "00:00:00:00:00:00:00:18:14",
        "00:00:00:00:00:00:00:18",
        "00:00:00:00:00:00:00:18:11",
        "00:00:00:00:00:00:00:11:11",
        "00:00:00:00:00:00:00:11",
        "00:00:00:00:00:00:00:11:1",
        "00:00:00:00:00:00:00:12:1",
        "00:00:00:00:00:00:00:12",
        "00:00:00:00:00:00:00:12:4",
        "00:00:00:00:00:00:00:15:4",
        "00:00:00:00:00:00:00:15",
        "00:00:00:00:00:00:00:15:54"
      ],
      "cost": 14
    },
    {
      "hops": [
        "00:00:00:00:00:00:00:21:60",
        "00:00:00:00:00:00:00:21",
        "00:00:00:00:00:00:00:21:14",
        "00:00:00:00:00:00:00:18:14",
        "00:00:00:00:00:00:00:18",
        "00:00:00:00:00:00:00:18:13",
        "00:00:00:00:00:00:00:19:13",
        "00:00:00:00:00:00:00:19",
        "00:00:00:00:00:00:00:19:12",
        "00:00:00:00:00:00:00:12:12",
        "00:00:00:00:00:00:00:12",
        "00:00:00:00:00:00:00:12:4",
        "00:00:00:00:00:00:00:15:4",
        "00:00:00:00:00:00:00:15",
        "00:00:00:00:00:00:00:15:54"
      ],
      "cost": 14
    }
  ]
}
```

### End-to-End Tests

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.0.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-10.2, timeout-2.1.0, anyio-3.6.2
collected 227 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 26%]
tests/test_e2e_11_mef_eline.py ......                                    [ 29%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 32%]
tests/test_e2e_13_mef_eline.py .....xs.s......xs.s.XXxX.xxxx..X......... [ 50%]
...                                                                      [ 51%]
tests/test_e2e_14_mef_eline.py x                                         [ 52%]
tests/test_e2e_15_mef_eline.py ..                                        [ 53%]
tests/test_e2e_20_flow_manager.py ......................                 [ 62%]
tests/test_e2e_21_flow_manager.py ...                                    [ 63%]
tests/test_e2e_22_flow_manager.py ...............                        [ 70%]
tests/test_e2e_23_flow_manager.py ..............                         [ 76%]
tests/test_e2e_30_of_lldp.py ....                                        [ 78%]
tests/test_e2e_31_of_lldp.py ...                                         [ 79%]
tests/test_e2e_32_of_lldp.py ...                                         [ 81%]
tests/test_e2e_40_sdntrace.py ...........                                [ 85%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 89%]
tests/test_e2e_50_maintenance.py ........................                [100%]
=============================== warnings summary ===============================
= 205 passed, 6 skipped, 11 xfailed, 5 xpassed, 799 warnings in 10444.28s (2:54:04) 
```
