### PR TITLE
Added user-friendly UI for pathfinder best paths.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,11 @@ Removed
 - ``desired_links`` is no longer supported. If used to use ``desired_links`` you can try to parametrize it with a different constraint for instance ``undesired_links`` or with ``mandatory_metrics``.
 - ``POST /v2/`` has been removed
 
+Changed
+=======
+- Changed UI ``k-accordion-item`` in best-path.kytos. Interfaces are displayed using their port names or names rather than address. Switches are rendered using node names or id rather than address.
+
+
 [2022.3.0] - 2022-12-15
 ***********************
 

--- a/ui/k-info-panel/best_path.kytos
+++ b/ui/k-info-panel/best_path.kytos
@@ -1,16 +1,14 @@
 <template>
     <k-accordion>
       <k-accordion-item title="Best Paths">
-          <div>
             <k-property-panel v-for="(path, index) in content">
               <k-accordion-item :title=format_title(index,path['cost'])>
-                <k-property-panel-item v-for="(cur_path, path_index) in path['hops']"
-                                       v-if="content" :name="String(path_index)" :value="cur_path"
+                <k-property-panel-item v-for="(current_path, path_index) in path['hops']"
+                                       v-if="content" :name="String(path_index)" :value="format_hop(current_path)"
                                        :key="path_index">
                 </k-property-panel-item>
               </k-accordion-item>
             </k-property-panel>
-          </div>
         </k-accordion-item>
     </k-accordion>
 </template>
@@ -21,7 +19,26 @@
    methods: {
      format_title(index, cost){
         return "Path " + index + ", cost: " + cost + ", hops: ";
-     }
+     },
+     is_switch(path) {
+      return path.split(":").length - 1 === 7;
+     },
+     format_hop(current_path) {
+      let base_path = current_path.split(':').slice(0, 8).join(':')
+      let switch_data = this.get_switch_data(base_path)
+      if (this.is_switch(current_path)) {
+        if ('metadata' in switch_data && 'node_name' in switch_data.metadata) return switch_data.metadata.node_name;
+        return switch_data.id;
+      }
+      else {
+        let interface_data = switch_data['interfaces'][current_path];
+        if ('metadata' in interface_data && 'port_name' in interface_data.metadata) return interface_data.metadata.port_name;
+        return interface_data.name;
+      }
+     },
+     get_switch_data(base_path) {
+      return self.switches.filter(object => object.id === base_path)[0]
+     },
    },
    data () {
      return {


### PR DESCRIPTION
Closes #17

### Summary

Makes best paths UI render a name in that list in a user-friendly manner, using the following rules
- `interface.metadata.port_name` if it's an interface and if this attribute is set and not empty, otherwise `interface.name`
- `switch.metadata.node_name` if it's an switch and if this attribute is set and not empty, otherwise `switch.id`


### Local Tests
It renders the UI in a user-friendly manner:
![image](https://github.com/kytos/pathfinder/assets/84760072/29345737-84c6-43ab-a88d-7344740647e3)

### End-to-End Tests