### PR TITLE
fix:  replaced `kytos/topology.links.metadata.(added|removed)` with `kytos/topology.updated`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,12 @@ Removed
 =======
 - ``desired_links`` is no longer supported. If used to use ``desired_links`` you can try to parametrize it with a different constraint for instance ``undesired_links`` or with ``mandatory_metrics``.
 - ``POST /v2/`` has been removed
+- Removed ``on_links_metadata_changed`` and topology reconciliation
+
+Changed
+=======
+
+- link metadata changes will be updated via ``kytos/topology.updated``
 
 [2022.3.0] - 2022-12-15
 ***********************

--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,6 @@ Subscribed
 
 - ``kytos/topology.topology_loaded``
 - ``kytos/topology.updated``
-- ``kytos/topology.links.metadata.(added|removed)``
 
 .. TAGs
 

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ import pathlib
 from threading import Lock
 from typing import Generator
 
-from kytos.core import KytosEvent, KytosNApp, log, rest
+from kytos.core import KytosNApp, log, rest
 from kytos.core.helpers import listen_to, load_spec, validate_openapi
 from kytos.core.rest_api import (HTTPException, JSONResponse, Request,
                                  get_json_or_400)
@@ -141,7 +141,6 @@ class Main(KytosNApp):
 
     @listen_to(
         "kytos.topology.updated",
-        "kytos/topology.current",
         "kytos/topology.topology_loaded",
     )
     def on_topology_updated(self, event):
@@ -165,29 +164,3 @@ class Main(KytosNApp):
         switches = list(topology.switches.keys())
         links = list(topology.links.keys())
         log.debug(f"Topology graph updated with switches: {switches}, links: {links}.")
-
-    def update_links_metadata_changed(self, event) -> None:
-        """Update the graph when links' metadata are added or removed."""
-        link = event.content["link"]
-        try:
-            with self._lock:
-                if (
-                    link.id in self._links_updated_at
-                    and self._links_updated_at[link.id] > event.timestamp
-                ):
-                    return
-                self.graph.update_link_metadata(link)
-                self._links_updated_at[link.id] = event.timestamp
-            metadata = event.content["metadata"]
-            log.debug(f"Topology graph updated link id: {link.id} metadata: {metadata}")
-        except KeyError as exc:
-            log.warning(
-                f"Unexpected KeyError {str(exc)} on event {event}."
-                " pathfinder will reconciliate the topology"
-            )
-            self.controller.buffers.app.put(KytosEvent(name="kytos/topology.get"))
-
-    @listen_to("kytos/topology.links.metadata.(added|removed)")
-    def on_links_metadata_changed(self, event):
-        """Update the graph when links' metadata are added or removed."""
-        self.update_links_metadata_changed(event)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -257,55 +257,6 @@ class TestMain:
         )
         self.napp.update_topology(event)
 
-    async def test_update_links_changed(self):
-        """Test update_links_metadata_changed."""
-        self.napp.graph.update_link_metadata = MagicMock()
-        self.napp.controller.buffers.app.put = MagicMock()
-        event = KytosEvent(
-            name="kytos.topology.links.metadata.added",
-            content={"link": MagicMock(), "metadata": {}}
-        )
-        self.napp.update_links_metadata_changed(event)
-        assert self.napp.graph.update_link_metadata.call_count == 1
-        assert self.napp.controller.buffers.app.put.call_count == 0
-
-    async def test_update_links_changed_out_of_order(self):
-        """Test update_links_metadata_changed out of order."""
-        self.napp.graph.update_link_metadata = MagicMock()
-        self.napp.controller.buffers.app.put = MagicMock()
-        link = MagicMock(id="1")
-        assert link.id not in self.napp._links_updated_at
-        event = KytosEvent(
-            name="kytos.topology.links.metadata.added",
-            content={"link": link, "metadata": {}}
-        )
-        self.napp.update_links_metadata_changed(event)
-        assert self.napp.graph.update_link_metadata.call_count == 1
-        assert self.napp.controller.buffers.app.put.call_count == 0
-        assert self.napp._links_updated_at[link.id] == event.timestamp
-
-        second_event = KytosEvent(
-            name="kytos.topology.links.metadata.added",
-            content={"link": link, "metadata": {}}
-        )
-        second_event.timestamp = event.timestamp - timedelta(seconds=10)
-        self.napp.update_links_metadata_changed(second_event)
-        assert self.napp.graph.update_link_metadata.call_count == 1
-        assert self.napp.controller.buffers.app.put.call_count == 0
-        assert self.napp._links_updated_at[link.id] == event.timestamp
-
-    async def test_update_links_changed_key_error(self):
-        """Test update_links_metadata_changed key_error."""
-        self.napp.graph.update_link_metadata = MagicMock()
-        self.napp.controller.buffers.app.put = MagicMock()
-        event = KytosEvent(
-            name="kytos.topology.links.metadata.added",
-            content={"link": MagicMock()}
-        )
-        self.napp.update_links_metadata_changed(event)
-        assert self.napp.graph.update_link_metadata.call_count == 1
-        assert self.napp.controller.buffers.app.put.call_count == 1
-
     async def test_shortest_path(self, event_loop):
         """Test shortest path."""
         self.napp.controller.loop = event_loop


### PR DESCRIPTION
Closes #54 
Closes #53 

(I'll send a PR backporting soon)

### Summary

See updated changelog file (for more information about why, check out issue 54)

### Local Tests

Successfully added "blue" and "red" ownership to a ring topology, and provisioned with primary constraints "blue" which has higher hop count:

```
2023-07-06 17:08:14,323 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:33664 - "POST /api/kytos/topology/v3/links/c8b55359990f89a5849813dc348d30e9e1f991bad1
dcb7f82112bd35429d9b07/metadata HTTP/1.1" 201
kytos $> 2023-07-06 17:09:03,411 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:42672 - "POST /api/kytos/topology/v3/links/4d42dc0852278accac7d9df15418f6d92
1db160b13d674029a87cef1b5f67f30/metadata HTTP/1.1" 201
2023-07-06 17:09:15,367 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:60088 - "POST /api/kytos/topology/v3/links/78282c4d5b579265f04ebadc4405ca1b49628eb1d6
84bb45e5d0607fa8b713d0/metadata HTTP/1.1" 201

```

![20230706_171028](https://github.com/kytos-ng/pathfinder/assets/1010796/a63fe6a4-5bd9-4514-bf32-c7f0af228228)

![20230706_172016](https://github.com/kytos-ng/pathfinder/assets/1010796/88f37f61-744a-4b1c-ac0a-a6c5737f4084)


### End-to-End Tests

I'll dispatch e2e exec shortly and post the results here later
