### PR TITLE
[release 2022.3.1] fix:  replaced `kytos/topology.links.metadata.(added|removed)` with `kytos/topology.updated`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,18 @@ All notable changes to the pathfinder NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2022.3.1] - 2022-07-06
+***********************
+
+Removed
+=======
+- Removed ``on_links_metadata_changed`` and topology reconciliation
+
+Changed
+=======
+
+- link metadata changes will be updated via ``kytos/topology.updated``
+
 [2022.3.0] - 2022-12-15
 ***********************
 

--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,6 @@ Subscribed
 
 - ``kytos/topology.topology_loaded``
 - ``kytos/topology.updated``
-- ``kytos/topology.links.metadata.(added|removed)``
 
 .. TAGs
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "pathfinder",
   "description": "Keeps track of topology changes, and calculates the best path between two points.",
-  "version": "2022.3.0",
+  "version": "2022.3.1",
   "napp_dependencies": ["kytos/topology"],
   "license": "MIT",
   "tags": ["pathfinder", "rest", "work-in-progress"],

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ from threading import Lock
 from typing import Generator
 
 from flask import jsonify, request
-from kytos.core import KytosEvent, KytosNApp, log, rest
+from kytos.core import KytosNApp, log, rest
 from kytos.core.helpers import listen_to
 from napps.kytos.pathfinder.graph import KytosGraph
 # pylint: disable=import-error
@@ -225,7 +225,6 @@ class Main(KytosNApp):
 
     @listen_to(
         "kytos.topology.updated",
-        "kytos/topology.current",
         "kytos/topology.topology_loaded",
     )
     def on_topology_updated(self, event):
@@ -249,29 +248,3 @@ class Main(KytosNApp):
         switches = list(topology.switches.keys())
         links = list(topology.links.keys())
         log.debug(f"Topology graph updated with switches: {switches}, links: {links}.")
-
-    def update_links_metadata_changed(self, event) -> None:
-        """Update the graph when links' metadata are added or removed."""
-        link = event.content["link"]
-        try:
-            with self._lock:
-                if (
-                    link.id in self._links_updated_at
-                    and self._links_updated_at[link.id] > event.timestamp
-                ):
-                    return
-                self.graph.update_link_metadata(link)
-                self._links_updated_at[link.id] = event.timestamp
-            metadata = event.content["metadata"]
-            log.debug(f"Topology graph updated link id: {link.id} metadata: {metadata}")
-        except KeyError as exc:
-            log.warning(
-                f"Unexpected KeyError {str(exc)} on event {event}."
-                " pathfinder will reconciliate the topology"
-            )
-            self.controller.buffers.app.put(KytosEvent(name="kytos/topology.get"))
-
-    @listen_to("kytos/topology.links.metadata.(added|removed)")
-    def on_links_metadata_changed(self, event):
-        """Update the graph when links' metadata are added or removed."""
-        self.update_links_metadata_changed(event)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -282,55 +282,6 @@ class TestMain(TestCase):
         )
         self.napp.update_topology(event)
 
-    def test_update_links_changed(self):
-        """Test update_links_metadata_changed."""
-        self.napp.graph.update_link_metadata = MagicMock()
-        self.napp.controller.buffers.app.put = MagicMock()
-        event = KytosEvent(
-            name="kytos.topology.links.metadata.added",
-            content={"link": MagicMock(), "metadata": {}}
-        )
-        self.napp.update_links_metadata_changed(event)
-        assert self.napp.graph.update_link_metadata.call_count == 1
-        assert self.napp.controller.buffers.app.put.call_count == 0
-
-    def test_update_links_changed_out_of_order(self):
-        """Test update_links_metadata_changed out of order."""
-        self.napp.graph.update_link_metadata = MagicMock()
-        self.napp.controller.buffers.app.put = MagicMock()
-        link = MagicMock(id="1")
-        assert link.id not in self.napp._links_updated_at
-        event = KytosEvent(
-            name="kytos.topology.links.metadata.added",
-            content={"link": link, "metadata": {}}
-        )
-        self.napp.update_links_metadata_changed(event)
-        assert self.napp.graph.update_link_metadata.call_count == 1
-        assert self.napp.controller.buffers.app.put.call_count == 0
-        assert self.napp._links_updated_at[link.id] == event.timestamp
-
-        second_event = KytosEvent(
-            name="kytos.topology.links.metadata.added",
-            content={"link": link, "metadata": {}}
-        )
-        second_event.timestamp = event.timestamp - timedelta(seconds=10)
-        self.napp.update_links_metadata_changed(second_event)
-        assert self.napp.graph.update_link_metadata.call_count == 1
-        assert self.napp.controller.buffers.app.put.call_count == 0
-        assert self.napp._links_updated_at[link.id] == event.timestamp
-
-    def test_update_links_changed_key_error(self):
-        """Test update_links_metadata_changed key_error."""
-        self.napp.graph.update_link_metadata = MagicMock()
-        self.napp.controller.buffers.app.put = MagicMock()
-        event = KytosEvent(
-            name="kytos.topology.links.metadata.added",
-            content={"link": MagicMock()}
-        )
-        self.napp.update_links_metadata_changed(event)
-        assert self.napp.graph.update_link_metadata.call_count == 1
-        assert self.napp.controller.buffers.app.put.call_count == 1
-
     def test_shortest_path(self):
         """Test shortest path."""
         self.setting_path()


### PR DESCRIPTION
### Summary

This is backport from https://github.com/kytos-ng/pathfinder/pull/55, check [PR 55](https://github.com/kytos-ng/pathfinder/pull/55) out for more information.