### PR TITLE
chore: parametrized `dynamic_single` pool to handle out of order events 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,7 @@ Changed
 =======
 
 - link metadata changes will be updated via ``kytos/topology.updated``
+- ``on_topology_updated`` has been refactored to use ``dynamic_single`` to simplify ensuring FIFO event processing.
 
 [2022.3.0] - 2022-12-15
 ***********************

--- a/main.py
+++ b/main.py
@@ -25,8 +25,6 @@ class Main(KytosNApp):
         self.graph = KytosGraph()
         self._topology = None
         self._lock = Lock()
-        self._topology_updated_at = None
-        self._links_updated_at = {}
 
     def execute(self):
         """Do nothing."""
@@ -142,6 +140,7 @@ class Main(KytosNApp):
     @listen_to(
         "kytos.topology.updated",
         "kytos/topology.topology_loaded",
+        pool="dynamic_single"
     )
     def on_topology_updated(self, event):
         """Update the graph when the network topology is updated."""
@@ -153,13 +152,7 @@ class Main(KytosNApp):
             return
         topology = event.content["topology"]
         with self._lock:
-            if (
-                self._topology_updated_at
-                and self._topology_updated_at > event.timestamp
-            ):
-                return
             self._topology = topology
-            self._topology_updated_at = event.timestamp
             self.graph.update_topology(topology)
         switches = list(topology.switches.keys())
         links = list(topology.links.keys())

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,7 +1,6 @@
 """Test Main methods."""
 
 from unittest.mock import MagicMock, patch
-from datetime import timedelta
 
 from kytos.core.events import KytosEvent
 from kytos.lib.helpers import get_controller_mock, get_test_client
@@ -29,29 +28,6 @@ class TestMain:
             name="kytos.topology.updated", content={"topology": topology}
         )
         self.napp.update_topology(event)
-        assert self.napp._topology == topology
-
-    def test_update_topology_events_out_of_order(self):
-        """Test update topology events out of order.
-
-        If a subsequent older event is sent, then the topology
-        shouldn't get updated.
-        """
-        topology = get_topology_mock()
-        assert self.napp._topology_updated_at is None
-        first_event = KytosEvent(
-            name="kytos.topology.updated", content={"topology": topology}
-        )
-        self.napp.update_topology(first_event)
-        assert self.napp._topology_updated_at == first_event.timestamp
-        assert self.napp._topology == topology
-
-        second_topology = get_topology_mock()
-        second_event = KytosEvent(
-            name="kytos.topology.updated", content={"topology": second_topology}
-        )
-        second_event.timestamp = first_event.timestamp - timedelta(seconds=10)
-        self.napp.update_topology(second_event)
         assert self.napp._topology == topology
 
     def test_update_topology_failure_case(self):


### PR DESCRIPTION
Related to https://github.com/kytos-ng/kytos/pull/399 (it depends on it)

### Summary

- ``on_topology_updated`` has been refactored to use ``dynamic_single`` `listen_to` arg to simplify ensuring FIFO event processing. So, the `self._topology_updated_at` safe lock guards were removed.

#### Side note

We could still completely leverage `async` but it'll be addressed in a future opportunity on issue #57

### Local Tests

I ran a stress test with link_flap on a ring topology (same script as used on this related PR https://github.com/kytos-ng/topology/pull/132), 500 flaps over 5 iteration to simulate topology update, by the end of the test pathfinder still found both expected paths:

```
❯ sudo python flap.py
link_flap test iteration 0
         waiting for 10 secs before next iteration
link_flap test iteration 1
         waiting for 10 secs before next iteration
link_flap test iteration 2
         waiting for 10 secs before next iteration
link_flap test iteration 3
         waiting for 10 secs before next iteration
link_flap test iteration 4
         waiting for 10 secs before next iteration

```

```
❯ curl -s -X POST -H 'Content-type: application/json' http://127.0.0.1:8181/api/kytos/pathfinder/v3/ -d '{"source": "00:00:00:00:00:00:00:01:1", "destination":  "00:00:00:00:00:00:00:03:
1"}' | jq -r
{
  "paths": [
    {
      "hops": [
        "00:00:00:00:00:00:00:01:1",
        "00:00:00:00:00:00:00:01",
        "00:00:00:00:00:00:00:01:4",
        "00:00:00:00:00:00:00:03:3",
        "00:00:00:00:00:00:00:03",
        "00:00:00:00:00:00:00:03:1"
      ],
      "cost": 5
    },
    {
      "hops": [
        "00:00:00:00:00:00:00:01:1",
        "00:00:00:00:00:00:00:01",
        "00:00:00:00:00:00:00:01:3",
        "00:00:00:00:00:00:00:02:2",
        "00:00:00:00:00:00:00:02",
        "00:00:00:00:00:00:00:02:3",
        "00:00:00:00:00:00:00:03:2",
        "00:00:00:00:00:00:00:03",
        "00:00:00:00:00:00:00:03:1"
      ],
      "cost": 8
    }
  ]
}
```

Mid test when the interface was going down, only one path was found as expected:

```
❯ curl -s -X POST -H 'Content-type: application/json' http://127.0.0.1:8181/api/kytos/pathfinder/v3/ -d '{"source": "00:00:00:00:00:00:00:01:1", "destination":  "00:00:00:00:00:00:00:03:
1"}' | jq -r
{
  "paths": [
    {
      "hops": [
        "00:00:00:00:00:00:00:01:1",
        "00:00:00:00:00:00:00:01",
        "00:00:00:00:00:00:00:01:3",
        "00:00:00:00:00:00:00:02:2",
        "00:00:00:00:00:00:00:02",
        "00:00:00:00:00:00:00:02:3",
        "00:00:00:00:00:00:00:03:2",
        "00:00:00:00:00:00:00:03",
        "00:00:00:00:00:00:00:03:1"
      ],
      "cost": 8
    }
  ]
}

```

### End-to-End Tests

I'll dispatch e2e exec shortly and I'll post the results here later.
