### PR TITLE
chore: update changelog for pr 51 and 52

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,15 @@ All notable changes to the pathfinder NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+Added
+=====
+- Added UI autocomplete for source and destination
+
+Changed
+=======
+- Changed UI ``k-accordion-item`` in best-path.kytos. Interfaces are displayed using their port names or names rather than address. Switches are rendered using node names or id rather than address.
+
+
 [2023.1.0] - 2023-06-05
 ***********************
 
@@ -13,7 +22,6 @@ Added
 =====
 - ``POST /v3/`` has replaced ``POST /v2/``
 - ``POST /v3/`` now validates its OpenAPI spec
-- Added autocomplete for source and destination
 
 Fixed
 =====
@@ -31,10 +39,6 @@ Changed
 
 - link metadata changes will be updated via ``kytos/topology.updated``
 - ``on_topology_updated`` has been refactored to use ``dynamic_single`` to simplify ensuring FIFO event processing.
-
-Changed
-=======
-- Changed UI ``k-accordion-item`` in best-path.kytos. Interfaces are displayed using their port names or names rather than address. Switches are rendered using node names or id rather than address.
 
 
 [2022.3.0] - 2022-12-15


### PR DESCRIPTION
When merging PR #51 and PR #52, I didn't have access to push to the PR branch, so I ended up merging the conflicting changelog anyway, and I'm fixing it on this PR

### Local tests

![20230828_163726](https://github.com/kytos-ng/pathfinder/assets/1010796/005ddb6d-2355-42ca-903a-fac31b9a8ca5)
