### PR TITLE
Updated item type on not_ownership in openapi.yml

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -202,6 +202,8 @@ components:
           example: "Bill"
         not_ownership:
           type: array
+          items:
+            type: string
           description: A list of users whose links we shouldn't use.
           example: ["Alice", "Bob"]
           


### PR DESCRIPTION
Ensures that the correct item type is used on the `not_ownership` array.

# Local Testing

Properly formatted `not_ownership` continues to be accepted.