### PR TITLE
Fixed disabled switches

### DIFF
--- a/graph/graph.py
+++ b/graph/graph.py
@@ -15,7 +15,7 @@ try:
     import networkx as nx
     from networkx.exception import NetworkXNoPath, NodeNotFound
 except ImportError:
-    PACKAGE = "networkx==2.5.1"
+    PACKAGE = "networkx==2.8.6"
     log.error(f"Package {PACKAGE} not found. Please 'pip install {PACKAGE}'")
 
 

--- a/graph/graph.py
+++ b/graph/graph.py
@@ -11,12 +11,8 @@ from .filters import EdgeFilter, ProcessEdgeAttribute, TypeCheckPreprocessor, Ty
 from .weights import (nx_edge_data_delay, nx_edge_data_priority, nx_edge_data_weight)
 
 
-try:
-    import networkx as nx
-    from networkx.exception import NetworkXNoPath, NodeNotFound
-except ImportError:
-    PACKAGE = "networkx==2.8.6"
-    log.error(f"Package {PACKAGE} not found. Please 'pip install {PACKAGE}'")
+import networkx as nx
+from networkx.exception import NetworkXNoPath, NodeNotFound
 
 
 class KytosGraph:

--- a/tests/integration/test_paths.py
+++ b/tests/integration/test_paths.py
@@ -17,7 +17,6 @@ class TestPaths:
             "generate_topology" if not val else "generate_topology_" + str(val)
         )
         method = getattr(self, method_name)
-        method()
         switches, links = method()
 
         self.graph = KytosGraph()
@@ -37,6 +36,7 @@ class TestPaths:
         """Add a new switch to the list of switches"""
         switch = Switch(name)
         switch.is_active = lambda: True
+        switch.is_enabled = lambda: True
         switches[name] = switch
 
     @staticmethod


### PR DESCRIPTION
Closes #71

### Summary

Interface does not longer enable its switch, [code change](https://github.com/kytos-ng/kytos/pull/442/commits/5400abd94cb1c5f4f68a0c05eaa1128d04060a41#diff-8748b90d411cfa5baef706c756bbcfaf410f6c4c58d4a5e5e861cf9ea71067f8L572-L579). Tests were failing because the switches were `DISABLED`

### Local Tests
Run tox

### End-to-End Tests
N/A