### PR TITLE
Added `not ownership` to UI interface.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,8 @@ All notable changes to the pathfinder NApp will be documented in this file.
 Added
 =====
 - Added UI autocomplete for source and destination
-- Added ``not_ownership`` as a filter for pathfinding. Pass a list of strings of owners to filter out edges with any of the given owners. 
+- Added ``not_ownership`` as a filter for pathfinding. Pass a list of strings of owners to filter out edges with any of the given owners.
+- Added ``not_ownership`` filter to main UI interface.
 
 Changed
 =======

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -95,8 +95,11 @@
               <k-dropdown :options="metric_options['not_ownership']" 
               :value.sync="is_flexible.not_ownership"></k-dropdown>
             </div>
-            <k-input icon="arrow-right" placeholder="['blue', 'red']"
-                      :action="function(val) {try{metrics.not_ownership = JSON.parse(val)}catch(e){if(!(e instanceof SyntaxError)){throw e}}}">
+            <k-input icon="arrow-right" placeholder='["blue", "red"]' tooltip="Use double quotes for owners."
+                      :action="function(val){
+                        try{metrics.not_ownership = JSON.parse(val)}
+                        catch(e){if(e instanceof SyntaxError){metrics.not_ownership=val}else{throw e}}
+                      }">
             </k-input>
           </div>
           <div class="metric">
@@ -372,7 +375,7 @@ module.exports = {
         utilization: 0,
         priority: 0,
         ownership: "",
-        not_ownership: "",
+        not_ownership: [],
       },
       is_flexible:{
         bandwidth: false,

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -85,9 +85,20 @@
               <k-dropdown :options="metric_options['ownership']" 
               :value.sync="is_flexible.ownership"></k-dropdown>
             </div>
+            <k-input icon="arrow-right" :value.sync="metrics.ownership"></k-input>
           </div>
-          <k-input icon="arrow-right" :value.sync="metrics.ownership"></k-input>
-
+          <div class="metric">
+            <div class="checkbox">
+              <k-checkbox :model.sync = "checked_list" :value = "'not_ownership'"></k-checkbox>
+            </div>
+            <div class="dropdown">
+              <k-dropdown :options="metric_options['not_ownership']" 
+              :value.sync="is_flexible.not_ownership"></k-dropdown>
+            </div>
+            <k-input icon="arrow-right" placeholder="['blue', 'red']"
+                      :action="function(val) {try{metrics.not_ownership = JSON.parse(val)}catch(e){if(!(e instanceof SyntaxError)){throw e}}}">
+            </k-input>
+          </div>
           <div class="metric">
             <div>
               <k-input icon="arrow-right" placeholder="Minimum flexible hits"
@@ -235,6 +246,7 @@ module.exports = {
       var priority_options = []
       var ownership_options = []
       var spf_attribute_options = []
+      var not_ownership_options = []
 
       bandwidth_options.push({value: false, description: 'Bandwidth', selected: true});
       bandwidth_options.push({value: true, description: 'Bandwidth (Flexible)'});
@@ -254,12 +266,16 @@ module.exports = {
       ownership_options.push({value: false, description: 'Ownership', selected: true});
       ownership_options.push({value: true, description: 'Ownership (Flexible)'});
 
+      not_ownership_options.push({value: false, description: 'Not ownership', selected: true});
+      not_ownership_options.push({value: true, description: 'Not ownership (Flexible)'});
+
       metric_options["bandwidth"] = bandwidth_options
       metric_options["reliability"] = reliability_options
       metric_options["delay"] = delay_options
       metric_options["utilization"] = utilization_options
       metric_options["priority"] = priority_options
       metric_options["ownership"] = ownership_options
+      metric_options["not_ownership"] = not_ownership_options
 
       return metric_options;
     },
@@ -355,7 +371,8 @@ module.exports = {
         delay: 0,
         utilization: 0,
         priority: 0,
-        ownership: ""
+        ownership: "",
+        not_ownership: "",
       },
       is_flexible:{
         bandwidth: false,
@@ -363,7 +380,8 @@ module.exports = {
         delay: false,
         utilization: false,
         priority: false,
-        ownership: false
+        ownership: false,
+        not_ownership: false,
       },
       spf_attribute: "hop",
       spf_max_paths: 2,


### PR DESCRIPTION
Closes #67

### Summary

Added `not_ownership` section to main UI interface
![not_ownership](https://github.com/kytos-ng/pathfinder/assets/55767214/9cd12c83-7cb5-468f-9bdc-cdf8ded38908)


### Local Tests
Send a request with `'red'`, `"red"`, `['red']`, `["red"]` under `not_ownership`. Only the last one parses correctly

### End-to-End Tests
N/A