### PR TITLE
Migration to Vue3: additional change to make InfoPanel display maximized as before

### DIFF
--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -230,6 +230,7 @@ module.exports = {
                       "component": 'kytos-pathfinder-k-info-panel-best_path',
                       "content": this.paths,
                       "icon": "compass",
+                      "maximized": true,
                       "title": "Best Paths",
                       "subtitle": "by kytos/pathfinder"
                      }


### PR DESCRIPTION
Related to https://github.com/kytos-ng/ui/issues/35

### Summary

This PR should sit on top of https://github.com/kytos-ng/sdntrace_cp/pull/116 and it makes the InfoPanel be displayed maximized as it used to be before vue3 migration