### PR TITLE
release: bumped 2024.1.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,10 +6,12 @@ All notable changes to the pathfinder NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2024.1.0] - 2024-07-23
+***********************
+
 Changed
 =======
 - Updated python environment installation from 3.9 to 3.11
-- Updated test dependencies
 - Upgraded UI framework to Vue3
 
 [2023.2.0] - 2024-02-16

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "pathfinder",
   "description": "Keeps track of topology changes, and calculates the best path between two points.",
-  "version": "2023.2.0",
+  "version": "2024.1.0",
   "napp_dependencies": ["kytos/topology"],
   "license": "MIT",
   "tags": ["pathfinder", "rest", "work-in-progress"],


### PR DESCRIPTION
### Summary

release: bumped 2024.1.0

### Local Tests

N/A

### End-to-End Tests

e2e nightly tests are passing. N/A for this PR.
