### PR TITLE
Made changes for vue3sfcloader compatibility

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,14 @@ All notable changes to the pathfinder NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+Fixed
+=====
+- Added missing quotes to v-binds
+
+Added
+=====
+- Inputs used for display only were disabled
+
 [2024.1.0] - 2024-07-23
 ***********************
 

--- a/ui/k-info-panel/best_path.kytos
+++ b/ui/k-info-panel/best_path.kytos
@@ -4,7 +4,7 @@
       <k-accordion-item title="Best Paths">
           <template v-if="content">
             <k-property-panel v-for="(path, index) in content.paths">
-              <k-accordion-item :title=format_title(index,path['cost'])>
+              <k-accordion-item :title="format_title(index,path['cost'])">
                   <k-property-panel-item v-for="(current_path, path_index) in path['hops']"
                                         :name="String(path_index)" :value="format_hop(current_path)"
                                         :key="path_index">

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -11,7 +11,7 @@
                     @focus="get_interfaces"
                     @blur="onblur_interfaces"
                     >{{ source }}</k-input-auto>
-          <k-input class="k-input interface-label" v-model:value="source_name" icon="none"
+          <k-input :isDisabled="true" class="k-input interface-label" v-model:value="source_name" icon="none"
                     >{{ source_name }}</k-input> 
 
           <k-input-auto id="destination" v-model:value="destination"
@@ -21,7 +21,7 @@
                     @focus="get_interfaces"
                     @blur="onblur_interfaces"
                     >{{ destination }}</k-input-auto>
-          <k-input class="k-input interface-label" v-model:value="destination_name" icon="none"
+          <k-input :isDisabled="true" class="k-input interface-label" v-model:value="destination_name" icon="none"
                     >{{ destination_name }}</k-input> 
 
 


### PR DESCRIPTION
Closes #84 

### Summary

A v-bind was missing quotes; this was caught by the vue3-sfc-loader logger, so I added them in.
I disabled k-inputs that were only being used to display data so that the user didn't accidentally type in them.

### Local Tests

After applying the changes I no longer got the errors.
