### PR TITLE
Fixed try and catch block

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ All notable changes to the pathfinder NApp will be documented in this file.
 
 Fixed
 =====
+- Placed try and catch block into a Vue JS method
 - Added missing quotes to v-binds
 
 Added

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -96,10 +96,7 @@
               v-model:value="is_flexible.not_ownership"></k-dropdown>
             </div>
             <k-input icon="arrow-right" placeholder='["blue", "red"]' tooltip="Use double quotes for owners."
-                      :action="function(val){
-                        try{metrics.not_ownership = JSON.parse(val)}
-                        catch(e){if(e instanceof SyntaxError){metrics.not_ownership=val}else{throw e}}
-                      }">
+                      :action="notOwnershipInput(val)">
             </k-input>
           </div>
           <div class="metric">
@@ -144,6 +141,21 @@
 <script>
 module.exports = {
   methods: {
+    notOwnershipInput: function (val){
+      try {
+        this.metrics.not_ownership = JSON.parse(val)
+      }
+      catch (e) {
+        if (e instanceof SyntaxError)
+        {
+          this.metrics.not_ownership=val
+        }
+        else
+        {
+          throw e
+        }
+      }
+    },
     get_paths (){
       var self = this
       var mandatory_metrics = {}


### PR DESCRIPTION
Closes #85

### Summary

For some reason, try and catch blocks within HTML tags don't work properly and throw errors. This is why I made the try and catch block for the `not_ownership` metrics into a method and passed it to the HTML input.

### Local Tests

I tried to to use the `not_ownership` metrics and it functioned properly with no errors.

### End-to-End Tests
