### PR TITLE
fix: fixed RuntimeError: dictionary changed size, when updating the graph

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ All notable changes to the pathfinder NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+Fixed
+=====
+- Fixed RuntimeError: dictionary changed size, when updating the graph
+
 Changed
 =======
 - Updated python environment installation from 3.9 to 3.11

--- a/graph/graph.py
+++ b/graph/graph.py
@@ -84,8 +84,8 @@ class KytosGraph:
     def update_topology(self, topology):
         """Update all nodes and links inside the graph."""
         self.graph.clear()
-        self.update_nodes(topology.switches)
-        self.update_links(topology.links)
+        self.update_nodes(topology.switches.copy())
+        self.update_links(topology.links.copy())
 
     def update_nodes(self, nodes):
         """Update all nodes inside the graph."""
@@ -95,7 +95,7 @@ class KytosGraph:
                     continue
                 self.graph.add_node(node.id)
 
-                for interface in node.interfaces.values():
+                for interface in node.interfaces.copy().values():
                     if interface.status == EntityStatus.UP:
                         self.graph.add_node(interface.id)
                         self.graph.add_edge(node.id, interface.id)
@@ -114,7 +114,7 @@ class KytosGraph:
 
     def update_link_metadata(self, link):
         """Update link metadata."""
-        for key, value in link.metadata.items():
+        for key, value in link.metadata.copy().items():
             if key not in self._accepted_metadata:
                 continue
             endpoint_a = link.endpoint_a.id

--- a/tests/unit/graph/test_graph.py
+++ b/tests/unit/graph/test_graph.py
@@ -199,7 +199,7 @@ class TestGraph:
         endpoint_b_id = 2
         link.endpoint_a.id = endpoint_a_id
         link.endpoint_b.id = endpoint_b_id
-        link.metadata.items.return_value = [("reliability", 50)]
+        link.metadata = {"reliability": 50}
         self.kytos_graph.graph = graph
         self.kytos_graph.update_link_metadata(link)
         call_res = str(self.kytos_graph.graph._mock_mock_calls)


### PR DESCRIPTION
Closes #91 

### Summary

See updated changelog file 

### Local Tests

- Created an EVC using link metadata constraints

```
{
    "name": "inter_evpl",
    "service_level": 6,
    "dynamic_backup_path": true,
    "uni_a": {
        "interface_id": "00:00:00:00:00:00:00:01:1",
        "tag": {
            "tag_type": 1,
            "value": 301
        }
    },
    "uni_z": {
        "interface_id": "00:00:00:00:00:00:00:03:1",
        "tag": {
            "tag_type": 1,
            "value": 301
        }
    },
    "primary_constraints": {
        "mandatory_metrics": {
            "ownership": "blue"
        }
    },
    "secondary_constraints": {
        "mandatory_metrics": {
            "ownership": "blue"
        }
    }
}
```

```
❯ curl -s http://0.0.0.0:8181/api/kytos/topology/v3/ | jq | grep ownership
          "ownership": "blue",
          "ownership": "red",
          "ownership": "red",
```

```
2025-02-12 16:07:39,584 - INFO [uvicorn.access] (MainThread) 127.0.0.1:58666 - "POST /api/kytos/pathfinder/v3/ HTTP/1.1" 200
2025-02-12 16:07:39,594 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request command: add, force: False, dpids: ['00:00:00:00:00:00:00:01'], flows[0, 2
]: [{'match': {'in_port': 1, 'dl_vlan': 301}, 'cookie': 12266335727286152522, 'actions': [{'action_type': 'push_vlan', 'tag_type': 's'}, {'action_type': 'set_vlan', 'vlan_id': 1}, {'acti
on_type': 'output', 'port': 4}], 'owner': 'mef_eline', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}, {'match': {'in_port': 4, 'dl_vlan': 1}, 'cookie': 12266335727286152522, '
actions': [{'action_type': 'pop_vlan'}, {'action_type': 'output', 'port': 1}], 'owner': 'mef_eline', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}]
2025-02-12 16:07:39,594 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request command: add, force: False, dpids: ['00:00:00:00:00:00:00:03'], flows[0, 2
]: [{'match': {'in_port': 1, 'dl_vlan': 301}, 'cookie': 12266335727286152522, 'actions': [{'action_type': 'push_vlan', 'tag_type': 's'}, {'action_type': 'set_vlan', 'vlan_id': 1}, {'acti
on_type': 'output', 'port': 3}], 'owner': 'mef_eline', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}, {'match': {'in_port': 3, 'dl_vlan': 1}, 'cookie': 12266335727286152522, '
actions': [{'action_type': 'pop_vlan'}, {'action_type': 'output', 'port': 1}], 'owner': 'mef_eline', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}]
2025-02-12 16:07:39,594 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Flows received summary: {switch: 00:00:00:00:00:00:00:01, flows_length: 2}, {switch: 00:00:00:00:00:
00:00:03, flows_length: 2},  total_flows_length: 4
2025-02-12 16:07:39,604 - INFO [uvicorn.access] (MainThread) 127.0.0.1:58672 - "POST /api/kytos/flow_manager/v2/flows_by_switch/?force=False HTTP/1.1" 202
2025-02-12 16:07:39,613 - INFO [kytos.napps.kytos/mef_eline] (AnyIO worker thread) EVC(3ac75aa892ed4a, inter_evpl) was deployed.

```

### End-to-End Tests

I'll dispatch an exec with this  branch, I don't expect surprises, shallow copies on cheap resources. 
