### PR TITLE
release/2024.1.1: Fixed RuntimeError: dictionary changed size, when updating the graph

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to the pathfinder NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2024.1.1] - 2025-02-12
+***********************
+
+Fixed
+=====
+- Fixed RuntimeError: dictionary changed size, when updating the graph
+
 [2024.1.0] - 2024-07-23
 ***********************
 

--- a/graph/graph.py
+++ b/graph/graph.py
@@ -84,8 +84,8 @@ class KytosGraph:
     def update_topology(self, topology):
         """Update all nodes and links inside the graph."""
         self.graph.clear()
-        self.update_nodes(topology.switches)
-        self.update_links(topology.links)
+        self.update_nodes(topology.switches.copy())
+        self.update_links(topology.links.copy())
 
     def update_nodes(self, nodes):
         """Update all nodes inside the graph."""
@@ -95,7 +95,7 @@ class KytosGraph:
                     continue
                 self.graph.add_node(node.id)
 
-                for interface in node.interfaces.values():
+                for interface in node.interfaces.copy().values():
                     if interface.status == EntityStatus.UP:
                         self.graph.add_node(interface.id)
                         self.graph.add_edge(node.id, interface.id)
@@ -114,7 +114,7 @@ class KytosGraph:
 
     def update_link_metadata(self, link):
         """Update link metadata."""
-        for key, value in link.metadata.items():
+        for key, value in link.metadata.copy().items():
             if key not in self._accepted_metadata:
                 continue
             endpoint_a = link.endpoint_a.id

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "pathfinder",
   "description": "Keeps track of topology changes, and calculates the best path between two points.",
-  "version": "2024.1.0",
+  "version": "2024.1.1",
   "napp_dependencies": ["kytos/topology"],
   "license": "MIT",
   "tags": ["pathfinder", "rest", "work-in-progress"],

--- a/tests/unit/graph/test_graph.py
+++ b/tests/unit/graph/test_graph.py
@@ -199,7 +199,7 @@ class TestGraph:
         endpoint_b_id = 2
         link.endpoint_a.id = endpoint_a_id
         link.endpoint_b.id = endpoint_b_id
-        link.metadata.items.return_value = [("reliability", 50)]
+        link.metadata = {"reliability": 50}
         self.kytos_graph.graph = graph
         self.kytos_graph.update_link_metadata(link)
         call_res = str(self.kytos_graph.graph._mock_mock_calls)


### PR DESCRIPTION
Backporting PR #92 to 2024.1

### Summary

See updated changelog file 

### Local Tests

Unit test also passing:

```
============================================================================ 78 passed, 83 warnings in 11.29s ============================================================================
```

Same as the linked PR except on 2024.1:

```
     _   __      _
    | | / /     | |
    | |/ / _   _| |_ ___  ___          _ __   __ _
    |    \| | | | __/ _ \/ __| ______ | '_ \ / _` |
    | |\  \ |_| | || (_) \__ \|______|| | | | (_| |
    \_| \_/\__, |\__\___/|___/        |_| |_|\__, |
            __/ |                             __/ |
           |___/                             |___/
    
    Welcome to Kytos SDN Platform!

    Kytos website.: https://kytos-ng.github.io/about/
    Documentation.: https://github.com/kytos-ng/documentation/tree/master/tutorials/napps
    OF Address....: tcp://0.0.0.0:6653
    WEB UI........: http://0.0.0.0:8181/
    Kytos Version.: 2024.1.0

2025-02-12 16:17:07,108 - INFO [uvicorn.access] (MainThread) 127.0.0.1:60992 - "GET /api/kytos/mef_eline/v2/evc/?archived=false HTTP/1.1" 200
2025-02-12 16:17:10,133 - INFO [uvicorn.access] (MainThread) 127.0.0.1:57400 - "POST /api/kytos/pathfinder/v3/ HTTP/1.1" 200
2025-02-12 16:17:10,151 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: add, force: False,  flows[0, 2]: 
[{'match': {'in_port': 1, 'dl_vlan': 2223}, 'cookie': 12305563888060574029, 'actions': [{'action_type': 'push_vlan', 'tag_type': 's'}, {'action_type': 'set_vlan', 'vlan_id': 1}, {'actio
n_type': 'output', 'port': 4}], 'owner': 'mef_eline', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}, {'match': {'in_port': 4, 'dl_vlan': 1}, 'cookie': 12305563888060574029, '
actions': [{'action_type': 'pop_vlan'}, {'action_type': 'output', 'port': 1}], 'owner': 'mef_eline', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}]
2025-02-12 16:17:10,168 - INFO [uvicorn.access] (MainThread) 127.0.0.1:57402 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A01 HTTP/1.1" 202
2025-02-12 16:17:10,184 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:03, command: add, force: False,  flows[0, 2]: 
[{'match': {'in_port': 1, 'dl_vlan': 2223}, 'cookie': 12305563888060574029, 'actions': [{'action_type': 'push_vlan', 'tag_type': 's'}, {'action_type': 'set_vlan', 'vlan_id': 1}, {'actio
n_type': 'output', 'port': 3}], 'owner': 'mef_eline', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}, {'match': {'in_port': 3, 'dl_vlan': 1}, 'cookie': 12305563888060574029, '
actions': [{'action_type': 'pop_vlan'}, {'action_type': 'output', 'port': 1}], 'owner': 'mef_eline', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}]
2025-02-12 16:17:10,195 - INFO [uvicorn.access] (MainThread) 127.0.0.1:57412 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A03 HTTP/1.1" 202
2025-02-12 16:17:10,204 - INFO [kytos.napps.kytos/mef_eline] (AnyIO worker thread) EVC(c6252894b9a94d, inter_evpl) was deployed.
```

### End-to-End Tests

Same