### PR TITLE
Implemented retries for topology update failure

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,10 +9,15 @@ All notable changes to the pathfinder NApp will be documented in this file.
 Fixed
 =====
 - Fixed potential race condition with pathfinding, regarding which version of the topology to use. Now should always use latest version.
+- pathfinder will no longer crash because of mismatched link when updating topology. Instead it will retry and log the interfaces involved if it does not succeed.
 
 Changed
 =======
 - Internal refactoring updating UI components to use ``pinia``
+
+Removed
+=======
+- The graph is not longer updated after every `topology.updated` event.
 
 [2025.1.0] - 2025-04-14
 ***********************

--- a/README.rst
+++ b/README.rst
@@ -54,8 +54,7 @@ Events
 Subscribed
 ----------
 
-- ``kytos/topology.topology_loaded``
-- ``kytos/topology.updated``
+This NApps is not subscribed to any events.
 
 .. TAGs
 

--- a/exceptions.py
+++ b/exceptions.py
@@ -1,0 +1,5 @@
+"""pathfinder Exceptions."""
+
+
+class LinkNotFound(Exception):
+    """Error when a link is not found in the graph."""

--- a/exceptions.py
+++ b/exceptions.py
@@ -3,3 +3,6 @@
 
 class LinkNotFound(Exception):
     """Error when a link is not found in the graph."""
+    def __init__(self, msg, link=None):
+        self.link = link
+        super().__init__(msg)

--- a/graph/graph.py
+++ b/graph/graph.py
@@ -122,9 +122,8 @@ class KytosGraph:
             try:
                 self.graph[endpoint_a][endpoint_b][key] = value
             except KeyError:
-                msg = ("Failed to get link from graph. Missing link"
-                       f" was from interfaces [{endpoint_a}, {endpoint_b}].")
-                raise LinkNotFound(msg)
+                msg = f"Failed to get link from graph. Missing component: {link}"
+                raise LinkNotFound(msg, link)
 
     def get_link_metadata(self, endpoint_a, endpoint_b):
         """Return the metadata of a link."""

--- a/main.py
+++ b/main.py
@@ -136,8 +136,11 @@ class Main(KytosNApp):
                     weight=spf_attr,
                 )
             log.debug(f"Found paths: {paths}")
-        except (TypeError, LinkNotFound) as err:
+        except TypeError as err:
             raise HTTPException(400, str(err))
+        except LinkNotFound as err:
+            log.error(f"Link {err.link} not found in pathfinder graph.")
+            raise HTTPException(409, str(err))
 
         paths = self._filter_paths_le_cost(paths, max_cost=spf_max_path_cost)
         log.debug(f"Filtered paths: {paths}")

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -326,3 +326,17 @@ class TestMain:
         self.napp._get_latest_topology()
         assert self.napp._topology is not None
         assert mock_update_topology.call_count == 4
+
+    @patch("napps.kytos.pathfinder.graph.graph.KytosGraph.update_topology")
+    async def test_shortest_path_link_not_found(self, mock_update_topology):
+        """Test shortest_path when a link is not found and returns 409."""
+        self.napp.controller.loop = asyncio.get_running_loop()
+        self.napp.controller.napps[("kytos", "topology")] = MagicMock()
+        mock_update_topology.side_effect = LinkNotFound("")
+        data = {
+            "source": "00:00:00:00:00:00:00:01:1",
+            "destination": "00:00:00:00:00:00:00:03:1",
+            "spf_max_paths": 10
+        }
+        response = await self.api_client.post(self.endpoint, json=data)
+        assert response.status_code == 409

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,12 +1,13 @@
 """Test Main methods."""
 import asyncio
+import pytest
 from unittest.mock import MagicMock, patch
 
-from kytos.core.events import KytosEvent
 from kytos.lib.helpers import get_controller_mock, get_test_client
 
 # pylint: disable=import-error
 from napps.kytos.pathfinder.main import Main
+from napps.kytos.pathfinder.exceptions import LinkNotFound
 from tests.helpers import get_topology_mock, get_topology_with_metadata
 
 
@@ -21,20 +22,11 @@ class TestMain:
         self.api_client = get_test_client(self.controller, self.napp)
         self.endpoint = "kytos/pathfinder/v3/"
 
-    def test_update_topology_success_case(self):
+    def test_update_to_topology_success_case(self):
         """Test update topology method to success case."""
         topology = get_topology_mock()
-        event = KytosEvent(
-            name="kytos.topology.updated", content={"topology": topology}
-        )
-        self.napp.update_topology(event)
+        self.napp._update_to_topology(topology)
         assert self.napp._topology == topology
-
-    def test_update_topology_failure_case(self):
-        """Test update topology method to failure case."""
-        event = KytosEvent(name="kytos.topology.updated")
-        self.napp.update_topology(event)
-        assert not self.napp._topology
 
     def setting_shortest_path_mocked(self, mock_shortest_paths):
         """Set the primary elements needed to test the retrieving
@@ -228,10 +220,7 @@ class TestMain:
         """Set the primary elements needed to test the topology
         update process under a "real-simulated" scenario."""
         topology = get_topology_with_metadata()
-        event = KytosEvent(
-            name="kytos.topology.updated", content={"topology": topology}
-        )
-        self.napp.update_topology(event)
+        self.napp._update_to_topology(topology)
 
     async def test_shortest_path(self):
         """Test shortest path."""
@@ -318,3 +307,22 @@ class TestMain:
 
         assert self.napp._topology is None
         self.napp.graph.update_topology.assert_not_called()
+
+    @patch("napps.kytos.pathfinder.graph.graph.KytosGraph.update_topology")
+    def test_get_latest_topology_retry(self, mock_update_topology):
+        """Test retry from _get_latest_topology method."""
+        self.napp._topology = None
+        self.napp.controller.napps[("kytos", "topology")] = MagicMock()
+        mock_update_topology.side_effect = LinkNotFound("")
+
+        with pytest.raises(LinkNotFound):
+            self.napp._get_latest_topology()
+
+        assert self.napp._topology is None
+        assert mock_update_topology.call_count == 3
+
+        mock_update_topology.side_effect = None
+
+        self.napp._get_latest_topology()
+        assert self.napp._topology is not None
+        assert mock_update_topology.call_count == 4


### PR DESCRIPTION
Closes #106

### Summary

- Implemented retries for topology update failure
- Removed automatic topology update

### Local Tests
Updated unit tests
Manually modified graph to raise a KeyError from graph.
This is the response from a failed request
```
{
    "description": "Failed to get link from graph. Missing link was from interfaces [00:00:00:00:00:00:00:03:2, 00:00:00:00:00:00:00:02:3].",
    "code": 400
}
```

### End-to-End Tests
```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /
configfile: pytest.ini
plugins: rerunfailures-13.0, timeout-2.2.0, asyncio-1.1.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 300 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  7%]
tests/test_e2e_06_topology.py ....                                       [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 22%]
tests/test_e2e_11_mef_eline.py ........                                  [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 27%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 41%]
.                                                                        [ 41%]
tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
tests/test_e2e_16_mef_eline.py ..                                        [ 46%]
tests/test_e2e_17_mef_eline.py .....                                     [ 48%]
tests/test_e2e_18_mef_eline.py .....                                     [ 49%]
tests/test_e2e_20_flow_manager.py ............................           [ 59%]
tests/test_e2e_21_flow_manager.py ...                                    [ 60%]
tests/test_e2e_22_flow_manager.py ...............                        [ 65%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py .R...                                       [ 71%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 82%]
tests/test_e2e_50_maintenance.py ...............................         [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 94%]
tests/test_e2e_70_kytos_stats.py .........                               [ 97%]
tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
tests/test_e2e_90_kafka_events.py .                                      [100%]
```