### PR TITLE
release: bumped 2025.2.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,9 @@ All notable changes to the pathfinder NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2025.2.0] - 2026-02-02
+***********************
+
 Fixed
 =====
 - Fixed potential race condition with pathfinding, regarding which version of the topology to use. Now should always use latest version.

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "pathfinder",
   "description": "Keeps track of topology changes, and calculates the best path between two points.",
-  "version": "2025.1.0",
+  "version": "2025.2.0",
   "napp_dependencies": ["kytos/topology"],
   "license": "MIT",
   "tags": ["pathfinder", "rest", "work-in-progress"],


### PR DESCRIPTION
Related to https://github.com/kytos-ng/kytos/issues/603

### Summary

See updated changelog file 

### Local Tests

N/A

### End-to-End Tests

N/A (nightly tests passing)
