### PR TITLE
Scroll no longer affects title for results

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ All notable changes to the pathfinder NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+Fixed
+=====
+- The title of a table result not longer hides when scrolling down.
+
 [2025.2.0] - 2026-02-02
 ***********************
 

--- a/ui/k-info-panel/best_path.kytos
+++ b/ui/k-info-panel/best_path.kytos
@@ -3,14 +3,14 @@
     <k-accordion>
       <k-accordion-item title="Best Paths">
           <template v-if="content">
-            <k-property-panel v-for="(path, index) in content.paths">
-              <k-accordion-item :title="format_title(index,path['cost'])">
+            <k-accordion-item v-for="(path, index) in content.paths" :title="format_title(index,path['cost'])">
+              <k-property-panel>
                   <k-property-panel-item v-for="(current_path, path_index) in path['hops']"
                                         :name="String(path_index)" :value="format_hop(current_path)"
                                         :key="path_index">
                   </k-property-panel-item>
-              </k-accordion-item>
-            </k-property-panel>
+              </k-property-panel>
+            </k-accordion-item>
         </template>
       </k-accordion-item>
     </k-accordion>


### PR DESCRIPTION
Closes #109

### Summary
Changed order of k elements so scroll no longer affects title

### Local Tests
![pathfinder_PR](https://github.com/user-attachments/assets/362125df-7eb9-4611-880f-f868da5c0471)

### End-to-End Tests
N/A