### PR TITLE
Fixed unordered endpoints

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ All notable changes to the pathfinder NApp will be documented in this file.
 Fixed
 =====
 - The title of a table result not longer hides when scrolling down.
+- Fixed undesired links that used to leak because they were in a different order.
 
 [2025.2.0] - 2026-02-02
 ***********************

--- a/main.py
+++ b/main.py
@@ -51,7 +51,7 @@ class Main(KytosNApp):
             return endpoints
         endpoint_ids = self._map_endpoints_from_link_ids(links)
         for edge in self.graph.graph.edges:
-            if edge not in endpoint_ids:
+            if edge not in endpoint_ids and (edge[1], edge[0]) not in endpoint_ids:
                 endpoints.append(edge)
         return endpoints
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -216,6 +216,27 @@ class TestMain:
         non_excluded_edges = self.napp._non_excluded_edges(undesired)
         assert not non_excluded_edges
 
+    def test_filter_paths_response_on_undesired_reversed(self):
+        """Test filter paths when edges have reversed endpoints."""
+        self.napp._topology = get_topology_mock()
+        edges = [
+            (link.endpoint_b.id, link.endpoint_a.id)
+            for link in self.napp._topology.links.values()
+        ]
+        self.napp.graph.graph.edges = edges
+
+        undesired = ["1"]
+        non_excluded_edges = self.napp._non_excluded_edges(undesired)
+
+        assert non_excluded_edges == [
+            ("00:00:00:00:00:00:00:03:1", "00:00:00:00:00:00:00:01:2"),
+            ("00:00:00:00:00:00:00:03:2", "00:00:00:00:00:00:00:02:2"),
+        ]
+
+        undesired = ["1", "2", "3"]
+        non_excluded_edges = self.napp._non_excluded_edges(undesired)
+        assert not non_excluded_edges
+
     def setting_path(self):
         """Set the primary elements needed to test the topology
         update process under a "real-simulated" scenario."""


### PR DESCRIPTION
Closes #113 

### Summary

See updated changelog file and/or add any other summarized helpful information for reviewers

### Local Test
Exercised the test reported in the issue

### End-to-End Tests
Tests ran with kytos [PR](https://github.com/kytos-ng/kytos/pull/624) changes as well
```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /
configfile: pytest.ini
plugins: timeout-2.2.0, rerunfailures-13.0, asyncio-1.1.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 307 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  6%]
tests/test_e2e_06_topology.py .....                                      [  8%]
tests/test_e2e_08_topology.py .                                          [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 22%]
tests/test_e2e_11_mef_eline.py ........                                  [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 27%]
tests/test_e2e_13_mef_eline.py .......................ssss.............. [ 41%]
.                                                                        [ 41%]
tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
tests/test_e2e_16_mef_eline.py ..                                        [ 45%]
tests/test_e2e_17_mef_eline.py .....                                     [ 47%]
tests/test_e2e_18_mef_eline.py ......                                    [ 49%]
tests/test_e2e_20_flow_manager.py .............................          [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 64%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ......                                      [ 71%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 82%]
tests/test_e2e_50_maintenance.py ...............................         [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py .........                               [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
tests/test_e2e_90_kafka_events.py .                                      [ 99%]
tests/test_e2e_95_telemtry_int.py s                                      [100%]
```